### PR TITLE
(feat)helm: add chaos experiment charts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: alpine
+    steps:
+      - checkout
+      - run:
+          name: helm-github-pages
+          environment:
+            - GITHUB_PAGES_REPO: litmuschaos/chaos-charts
+          command: wget -O - https://raw.githubusercontent.com/litmuschaos/helm-github-pages/master/publish.sh | sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,117 @@
-# chaos-charts
-Helm Charts to run Litmus Chaos Experiments on Kubernetes 
+# CHAOS EXPERIMENT CHARTS FOR KUBERNETES
+
+These charts provide the specifications for running chaos experiments on a Kubernetes 
+cluster and are are consumed by the Litmus Chaos Operator. The charts are categorized
+based on the nature of the experiments. For example, chart are catgeorized as : general-K8s
+(k8schaos), storage-specific(openebschaos) and application-specific(mysql)charts.  
+
+The charts install Kubernetes custom resources (CRs) with support for creation-time 
+injection of chaos parameters (defaults present in Values.yaml). To know more about the
+chaos tests themselves and the parameters supported, visit [litmuschaos/litmus](https://github.com/litmuschaos/litmus)
+
+Follow the steps provided below to install the charts on your Kubernetes cluster
+
+## HELM SETUP
+
+- Get Helm
+
+```>> curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh```
+
+- Give permissions 
+
+```>> chmod 700 get_helm.sh```
+
+- Execute Helm installtion scripts
+
+```>> ./get_helm.sh```
+
+- Define the cluster-admin clusterrole (if not present) w/ permissions for all actions on all resources
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: cluster-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+```
+
+- Create the clusterrole 
+
+```
+>> kubectl create -f clusterrole.yaml
+```
+
+- Create Tiller service account in kube-system namespace, bind to clusterrole w/ clusterrolebinding
+
+```
+>> kubectl create serviceaccount -n kube-system tiller
+
+>> kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+```
+
+- Initialize helm w/ service account Tiller
+
+```
+>> helm init --service-account tiller
+```
+
+- Verify that the Tiller pods are up & running
+
+```
+>> kubectl --namespace kube-system get pods | grep tiller
+  tiller-deploy-2885612843-xrj5m   1/1       Running   0   2d
+```
+
+
+## INSTALL THE CHAOS HELM CHARTS
+
+- Add the litmuschaos helm repo: 
+
+```
+>> helm repo add litmuschaos https://litmuschaos.github.io/chaos-charts
+"litmuschaos" has been added to your repositories
+
+>> helm repo update
+Hang tight while we grab the latest from your chart repositories...
+...Skip local chart repository
+...Successfully got an update from the "litmuschaos" chart repository
+...Successfully got an update from the "stable" chart repository
+Update Complete. ⎈ Happy Helming!⎈```
+
+- List the available charts 
+
+```
+>> helm search chaos-charts
+NAME                    CHART VERSION   APP VERSION     DESCRIPTION                                       
+chaos-charts/k8schaos   0.1.0           1.0             Helm chart for Litmus Kubernetes Chaos Experiments
+```
+
+- Install the desired chaos chart from litmuchaos repo
+
+```
+helm install litmuschaos/k8schaos
+NAME:   kneeling-dingo
+LAST DEPLOYED: Fri May  3 16:20:30 2019
+NAMESPACE: default
+STATUS: DEPLOYED
+
+RESOURCES:
+==> v1alpha1/ChaosExperiment
+NAME            AGE
+container-kill  1s
+pod-delete      1s
+```

--- a/charts/k8schaos/.helmignore
+++ b/charts/k8schaos/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/k8schaos/Chart.yaml
+++ b/charts/k8schaos/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Helm chart for Litmus Kubernetes Chaos Experiments 
+name: k8schaos
+version: 0.1.0
+ 

--- a/charts/k8schaos/README.md
+++ b/charts/k8schaos/README.md
@@ -1,0 +1,5 @@
+## k8schaos: Litmus Chaos Experiments Bundle  
+
+Define k8s chaos experiment custom resources executed by the Litmus chaos operator 
+
+

--- a/charts/k8schaos/templates/.helmignore
+++ b/charts/k8schaos/templates/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/k8schaos/templates/NOTES.txt
+++ b/charts/k8schaos/templates/NOTES.txt
@@ -1,0 +1,1 @@
+## Run "kubectl get chaosexperiment <experiment name> -o yaml" to view experiment details

--- a/charts/k8schaos/templates/_helpers.tpl
+++ b/charts/k8schaos/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8schaos.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8schaos.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8schaos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/k8schaos/templates/chaosexperiment_crd.yaml
+++ b/charts/k8schaos/templates/chaosexperiment_crd.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosexperiments.litmuschaos.io
+  labels:
+    app.kubernetes.io/name: {{ include "k8schaos.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ include "k8schaos.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosExperiment
+    listKind: ChaosExperimentList
+    plural: chaosexperiments
+    singular: chaosexperiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/k8schaos/templates/container_kill.yaml
+++ b/charts/k8schaos/templates/container_kill.yaml
@@ -1,0 +1,67 @@
+---
+## An experiment is the definition of a chaos test and is listed as an item 
+## in the chaos engine to be run against a given app. The results upon running
+## this experiment is relayed back to the chaos engine which invoked it.
+
+## A predefined Chaos template. Analogy: *Similar* in function to storage 
+## classes. Will contain params "specific" to that chaos operation w/ default 
+## values explicitly specified.
+
+## Experiments can be pulled from litmus charts and are versioned based on 
+## chart.
+
+## Charts should (not?) be auto-upgraded
+
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+
+  ## Eventually launched chaos litmusbook/job will bear <name>-<hash>
+  name: container-kill
+  labels:
+    litmuschaos.io/name: {{ include "k8schaos.name" . }}
+    litmuschaos.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ include "k8schaos.chart" . }}
+
+description:
+  message: |
+    Kills a container belonging to an application pod 
+
+spec:
+{{- with .Values.configuration }}
+{{- with .containerKill }} 
+  
+  ## A low-level definition of chaos parameters which is fed to the executor
+  ## for running the experiment.
+
+  ## Some experiments need more info on the "object of chaos". For example, in case 
+  ## of container crash tests in a multi-container app, it is necessary to know both 
+  ## general app info (namespace, labels) as well as container name which has to undergo
+  ## failures. This Component info is generally kept to a minimum and passed as ENV to 
+  ## the actual chaos-runner/executor pod/container.
+ 
+  definition: 
+    labels:
+      name: container-kill
+    litmusbook: "/experiments/chaos/kubernetes/container_kill/run_litmus_test.yml"
+    image: {{ .executorImage }}
+    env:
+      - name: ANSIBLE_STDOUT_CALLBACK
+        value: {{ .ansibleStdoutCallback }}
+
+      - name: TARGET_CONTAINER
+        value: {{ .targetContainer }}
+
+      - name: KILL_MODE
+        value: {{ .killMode }}
+
+      ## The chaos operator can use different execution frameworks to achieve
+      ## to achieve a certain chaos operation. It could use Litmus or Chaostoolkit
+      ## etc..,
+      - name: LIB
+        value: {{ .executorLib }}
+    command: ["/bin/bash"]
+    args: ["-c", "ansible-playbook ./experiments/chaos/kubernetes/container_kill/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+    
+{{- end }}
+{{- end }} 

--- a/charts/k8schaos/templates/pod_delete.yaml
+++ b/charts/k8schaos/templates/pod_delete.yaml
@@ -1,0 +1,66 @@
+---
+## An experiment is the definition of a chaos test and is listed as an item 
+## in the chaos engine to be run against a given app. The results upon running
+## this experiment is relayed back to the chaos engine which invoked it.
+
+## A predefined Chaos template. Analogy: *Similar* in function to storage 
+## classes. Will contain params "specific" to that chaos operation w/ default 
+## values explicitly specified.
+
+## Experiments can be pulled from litmus charts and are versioned based on 
+## chart.
+
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+
+  ## Eventually launched chaos litmusbook/job will bear <name>-<hash>
+  name: pod-delete
+  labels:
+    litmuschaos.io/name: {{ include "k8schaos.name" . }}
+    litmuschaos.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ include "k8schaos.chart" . }}
+
+description:
+  message: |
+    Deletes a pod belonging to a deployment/statefulset/daemonset
+
+spec:
+{{- with .Values.configuration }}
+{{- with .podDelete }}
+  
+  ## A low-level definition of chaos parameters which is fed to the executor
+  ## for running the experiment.
+
+  ## Some experiments need more info on the "object of chaos". For example, in case 
+  ## of container crash tests in a multi-container app, it is necessary to know both 
+  ## general app info (namespace, labels) as well as container name which has to undergo
+  ## failures. This Component info is generally kept to a minimum and passed as ENV to 
+  ## the actual chaos-runner/executor pod/container.
+ 
+  definition: 
+    labels:
+      name: pod-delete
+    image: {{ .executorImage }}
+    litmusbook: "/experiments/chaos/kubernetes/pod_delete/run_litmus_test.yml"
+    env:
+      - name: ANSIBLE_STDOUT_CALLBACK
+        value: {{ .ansibleStdoutCallback }}
+
+      - name: TOTAL_CHAOS_DURATION
+        value: {{ .totalChaosDuration }}
+
+      - name: CHAOS_INTERVAL
+        value: {{ .chaosInterval }}
+
+      ## The chaos operator can use different execution frameworks to achieve
+      ## to achieve a certain chaos operation. It could use Litmus or Chaostoolkit
+      ## etc..,
+
+      - name: LIB
+        value: {{ .executorLib }}
+    command: ["/bin/bash"]
+    args: ["-c", "ansible-playbook ./experiments/chaos/kubernetes/pod_delete/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+{{- end }}
+{{- end }}

--- a/charts/k8schaos/values.yaml
+++ b/charts/k8schaos/values.yaml
@@ -1,0 +1,44 @@
+# Default values for k8schaos 
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+configuration:
+ 
+  # Parameters for the kind ChaosExperiment. These can be 
+  # overridden by the chaosEngine. The CRs can be manually
+  # edited with desired defaults for the following attributes
+  # as well. 
+
+  # Typically assigned at install time to map to the AUT
+  # (Application-Under-Test).
+  
+  podDelete:
+
+    # The chaos operator can use different execution frameworks to achieve
+    # to achieve a certain chaos operation. It could use Litmus or Chaostoolkit
+    # etc..,
+    executorLib: 
+
+    # Image version of the executor container
+    executorImage:        
+
+    # Plugin used to view playbooks logs
+    ansibleStdoutCallback: 
+
+    # Total Chaos Period
+    totalChaosDuration: 15
+
+    # Chaos Interval
+    chaosInterval: 5
+
+  containerKill: 
+
+    executorLib: 
+    executorImage: 
+    ansibleStdoutCallback: 
+
+    # Name of container to be killed
+    targetContainer: "nginx" 
+
+    # Type of kill operation
+    killMode: 


### PR DESCRIPTION
## Changes

- Make the initial commit for chaos-charts to bootstrap the repo
- The first-cut includes the k8schaos chart with following experiments
   - pod-delete
   - container-kill
- The experiment resource CRD templates have the following annotations included to ensure the CRD is installed before the resources & also to remove stale CRDs in case of re-install/upgrades. This is acceptable in case of the experiment resources as they are static in nature: 

  ```yaml
  "helm.sh/hook": crd-install
  "helm.sh/hook-delete-policy": "before-hook-creation"
  ```
- The helm charts are served from the gh-Pages of this repository itself, as per [helm practices](https://helm.sh/docs/developing_charts/)

Signed-off-by: ksatchit <karthik.s@openebs.io>
