### PR TITLE
(refactor)values: update chaos operator to official image

### DIFF
--- a/charts/chaosOperator/values.yaml
+++ b/charts/chaosOperator/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: ksatchit/chaos-operator
-  tag: trial4
+  repository: litmuschaos/chaos-operator
+  tag: ci
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

- Update chaos operator deployment with official image repo:tag