### PR TITLE
(refactor): add experiment id to spec

### DIFF
--- a/charts/kubernetes/templates/container_kill.yaml
+++ b/charts/kubernetes/templates/container_kill.yaml
@@ -39,7 +39,7 @@ spec:
   ## general app info (namespace, labels) as well as container name which has to undergo
   ## failures. This Component info is generally kept to a minimum and passed as ENV to 
   ## the actual chaos-runner/executor pod/container.
- 
+  id: "k8s-state-container-01" 
   definition: 
 
     labels:

--- a/charts/kubernetes/templates/pod_delete.yaml
+++ b/charts/kubernetes/templates/pod_delete.yaml
@@ -39,7 +39,7 @@ spec:
   ## general app info (namespace, labels) as well as container name which has to undergo
   ## failures. This Component info is generally kept to a minimum and passed as ENV to 
   ## the actual chaos-runner/executor pod/container.
- 
+  id: "k8s-state-pod-01"
   definition: 
 
     labels:


### PR DESCRIPTION

- Assigns an experiment ID to each experiment.
- Convention used: 
  - `<chart-name>-<category>-<sub-category>-<number/index>`
  - Example: k8s-state-pod-01

Note: The category & sub-category are kept in accordance with the bundling method followed in litmuschaos/community-charts


Signed-off-by: ksatchit <karthik.s@openebs.io>