### PR TITLE
(feat)chart: Add chart for OpenEBS pool failure

### DIFF
--- a/charts/openebs/network/experiments/openebs-pool-faliure.yml
+++ b/charts/openebs/network/experiments/openebs-pool-faliure.yml
@@ -1,0 +1,44 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Openebs pool failure check !
+kind: ChaosExperiment
+metadata:
+  labels:
+    litmuschaos.io/name: kubernetes
+  name: openebs-pool-failure
+  namespace: percona1
+spec:
+  definition:
+    args:
+    - -c
+    - ansible-playbook ./experiments/chaos/openebs_pool_failure/test.yml -i /etc/ansible/hosts
+      -vv; exit 0
+    command:
+    - /bin/bash
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: default
+    - name: OPERATOR_NAMESPACE
+      value: openebs
+    - name: APP_NAMESPACE
+      value: "percona1" 
+    - name: APP_LABEL
+      value: "name=percona123"
+    - name: APP_PVC
+      value: percona-mysql-claim
+    - name: LIVENESS_APP_LABEL
+      value: ""
+    - name: LIVENESS_APP_NAMESPACE
+      value: ""
+    - name: DATA_PERSISTENCE
+      value: ""
+    - name: CHAOS_TYPE
+      value: "pool-kill"
+    - name: CHAOS_ITERATIONS
+      value: "2"
+
+    image: ""
+    labels:
+      name: openebs-pool-failure
+    litmusbook: /experiments/chaos/openebs_pool_failure/run_litmus_test.yml 
+


### PR DESCRIPTION
Signed-off-by: udit <uditgaurav@gmail.com>

Added the following experiments for OpenEBS charts:
- [x] openebs-pool-failure 

Here are the logs :
[logs-opf.txt](https://github.com/litmuschaos/community-charts/files/3642326/logs-opf.txt)
