### PR TITLE
Added Openebs-Pool-Failure Experiment CR

### DIFF
--- a/charts/openebs/openebs-pool-failure/experiment.basetemplate.yaml
+++ b/charts/openebs/openebs-pool-failure/experiment.basetemplate.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     litmuschaos.io/name: openebs
   name: openebs-pool-failure
-  namespace: litmus
   version: {{ VERSION }}
 spec:
   definition:
@@ -22,11 +21,11 @@ spec:
     - name: ANSIBLE_STDOUT_CALLBACK
       value: default
     - name: APP_NAMESPACE
-      value: app-percona-ns
+      value: ""
     - name: APP_LABEL
-      value: "name=percona"
+      value: ""
     - name: APP_PVC
-      value: percona-mysql-claim
+      value: #mendatory field
     - name: LIVENESS_APP_LABEL
       value: ""
     - name: LIVENESS_APP_NAMESPACE

--- a/charts/openebs/openebs-pool-failure/experiment.basetemplate.yaml
+++ b/charts/openebs/openebs-pool-failure/experiment.basetemplate.yaml
@@ -5,10 +5,9 @@ description:
     Kill the pool pod and check if gets scheduled again
 kind: ChaosExperiment
 metadata:
-  labels:
-    litmuschaos.io/name: kubernetes
   name: openebs-pool-failure
   namespace: litmus
+  version: {{ VERSION }}
 spec:
   definition:
     args:
@@ -41,7 +40,7 @@ spec:
     configmaps:
     - name: pool-failure
       data:
-        parameters.yml:
+        parameters.yml: |
     litmusbook: /experiments/chaos/openebs_pool_failure/run_litmus_test.yml
 
 

--- a/charts/openebs/openebs-pool-failure/experiment.basetemplate.yaml
+++ b/charts/openebs/openebs-pool-failure/experiment.basetemplate.yaml
@@ -5,6 +5,8 @@ description:
     Kill the pool pod and check if gets scheduled again
 kind: ChaosExperiment
 metadata:
+  labels:
+    litmuschaos.io/name: openebs
   name: openebs-pool-failure
   namespace: litmus
   version: {{ VERSION }}

--- a/charts/openebs/openebs-pool-failure/experiment_cr.yml
+++ b/charts/openebs/openebs-pool-failure/experiment_cr.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Kill the pool pod and check if gets scheduled again
+kind: ChaosExperiment
+metadata:
+  labels:
+    litmuschaos.io/name: kubernetes
+  name: openebs-pool-failure
+  namespace: litmus
+spec:
+  definition:
+    args:
+    - -c
+    - ansible-playbook ./experiments/chaos/openebs_pool_failure/test.yml -i /etc/ansible/hosts
+      -vv; exit 0
+    command:
+    - /bin/bash
+    env:
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: default
+    - name: APP_NAMESPACE
+      value: app-percona-ns
+    - name: APP_LABEL
+      value: "name=percona"
+    - name: APP_PVC
+      value: percona-mysql-claim
+    - name: LIVENESS_APP_LABEL
+      value: ""
+    - name: LIVENESS_APP_NAMESPACE
+      value: ""
+    - name: DATA_PERSISTENCE
+      value: ""
+    - name: CHAOS_TYPE
+      value: "pool-kill"
+    - name: CHAOS_ITERATIONS
+      value: "2"
+    labels:
+      name: openebs-pool-failure
+    configmaps:
+    - name: pool-failure
+      data:
+        parameters.yml:
+    litmusbook: /experiments/chaos/openebs_pool_failure/run_litmus_test.yml
+
+

--- a/charts/openebs/openebs-pool-failure/openebs_target_failure.chartserviceversion.basetemplate.yaml
+++ b/charts/openebs/openebs-pool-failure/openebs_target_failure.chartserviceversion.basetemplate.yaml
@@ -5,16 +5,15 @@ metadata:
   annotations:
     categories: "OpenEBS"
     vendor: "CNCF"
-    createdAt: 2019-10-03T10:28:08Z
-    repository: https://github.com/litmuschaos/community-charts
+    repository: https://github.com/litmuschaos/chaos-charts
     support: https://slack.openebs.io/
 spec:
   displayName: Openebs-Pool-Failure 
   description: >
-     openebs pool failure contains chaos to disrupt state of openebs control-plane and data-plane resources. Experiments can inject random pod delete against openebs pool pod. 
+     Kill the pool pod and check if gets scheduled again. 
   keywords:
     - Kubernetes
-    - Pool
+    - Storage Pool
     - OpenEBS
   version: {{ VERSION }}
   maturity: alpha
@@ -24,6 +23,7 @@ spec:
   minKubeVersion: 1.12.0
   provider:
     name: Mayadata
+  readme: "https://github.com/mayadata-io/litmus/blob/master/experiments/chaos/openebs_pool_failure/README.md"
   links:
     - name: OpenEBS Website
       url: https://openebs.io

--- a/charts/openebs/openebs-pool-failure/openebs_target_failure.chartserviceversion.basetemplate.yaml
+++ b/charts/openebs/openebs-pool-failure/openebs_target_failure.chartserviceversion.basetemplate.yaml
@@ -19,7 +19,7 @@ spec:
   version: {{ VERSION }}
   maturity: alpha
   maintainers:
-    - name: shubham
+    - name: shubham chaudhary
       email: shubham.chaudhary@mayadata.io
   minKubeVersion: 1.12.0
   provider:

--- a/charts/openebs/openebs-pool-failure/openebs_target_failure.chartserviceversion.basetemplate.yaml
+++ b/charts/openebs/openebs-pool-failure/openebs_target_failure.chartserviceversion.basetemplate.yaml
@@ -1,0 +1,34 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: openebs-pool-failure
+  annotations:
+    categories: "OpenEBS"
+    vendor: "CNCF"
+    createdAt: 2019-10-03T10:28:08Z
+    repository: https://github.com/litmuschaos/community-charts
+    support: https://slack.openebs.io/
+spec:
+  displayName: Openebs-Pool-Failure 
+  description: >
+     openebs pool failure contains chaos to disrupt state of openebs control-plane and data-plane resources. Experiments can inject random pod delete against openebs pool pod. 
+  keywords:
+    - Kubernetes
+    - Pool
+    - OpenEBS
+  version: {{ VERSION }}
+  maturity: alpha
+  maintainers:
+    - name: shubham
+      email: shubham.chaudhary@mayadata.io
+  minKubeVersion: 1.12.0
+  provider:
+    name: Mayadata
+  links:
+    - name: OpenEBS Website
+      url: https://openebs.io
+    - name: Source Code
+      url: https://github.com/openebs/openebs
+  icon:
+    - url: ""
+      mediatype: ""


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Experiment CR for the Openebs-Pool-Failure

-  The name of file which contains data for configmap should be parameters.yml

**Please find the attached logs**
[logs-job-poolexp-withoutmap.txt](https://github.com/litmuschaos/chaos-charts/files/3675255/logs-job-poolexp-withoutmap.txt)
[logs-job-poolexp-withmap.txt](https://github.com/litmuschaos/chaos-charts/files/3675256/logs-job-poolexp-withmap.txt)
[logs-executor-poolexp-withoutmap.txt](https://github.com/litmuschaos/chaos-charts/files/3675259/logs-executor-poolexp-withoutmap.txt)
[logs-executor-poolexp-withmap.txt](https://github.com/litmuschaos/chaos-charts/files/3675260/logs-executor-poolexp-withmap.txt)
