### PR TITLE
feat[chart]: Add disk-fill experiment CR 

### DIFF
--- a/charts/generic/disk-fill/disk-fill.chartserviceversion.yaml
+++ b/charts/generic/disk-fill/disk-fill.chartserviceversion.yaml
@@ -1,8 +1,8 @@
 apiVersion: litmuchaos.io/v1alpha1
 kind: ChartServiceVersion
 metadata:
-  name: disk_fill
-  version: 0.1.3
+  name: disk-fill
+  version: 0.0.1
   annotations:
     categories: Kubernetes
     vendor: CNCF
@@ -10,7 +10,7 @@ metadata:
     repository: https://github.com/litmuschaos/chaos-charts
     support: https://slack.kubernetes.io/
 spec:
-  displayName: disk_fill
+  displayName: disk-fill
   categoryDescription: |
     Disk fill contains chaos to disrupt state of kubernetes resources. 
     - Causes (forced/graceful) Disk Stress by filling up the Ephemeral Storage of the Pod using one of it containers.
@@ -21,6 +21,8 @@ spec:
     - Kubernetes
     - Disk
     - State 
+  platforms:
+    - GKE
   maturity: alpha
   maintainers:
     - name: ksatchit

--- a/charts/generic/disk-fill/experiment.yml
+++ b/charts/generic/disk-fill/experiment.yml
@@ -5,7 +5,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: disk-fill
-  version: 0.1.1
+  version: 0.0.1
 spec:
   definition:
     permissions:
@@ -17,6 +17,7 @@ spec:
         - "litmuschaos.io"
       resources:
         - "daemonsets"
+        - "statefulsets"
         - "deployments"
         - "jobs"
         - "pods"


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

**_Add disk-fill experiment CR_** 

This PR contains the chaos-chart for the disk-fill experiment. In this experiment we fillup ephemeral storage of the pod using one of its containers.

Folder Added: 
- [X] chaos-charts/charts/generic/disk-fill

Files Added: 
- [X] disk-fill.chartserviceversion.yaml
- [X] experiment.yaml

Logs:
Operator Logs:
[operator_logs.txt](https://github.com/litmuschaos/chaos-charts/files/3826326/operator_logs.txt)
Runner Logs:
[runner_logs.txt](https://github.com/litmuschaos/chaos-charts/files/3826327/runner_logs.txt)
Job Logs:
[job_logs.txt](https://github.com/litmuschaos/chaos-charts/files/3826329/job_logs.txt)



