### PR TITLE
refactor[yaml]: Added chaos duration and chaos interval as env in target-pod-failure

### DIFF
--- a/charts/openebs/openebs-target-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-pod-failure/experiment.yaml
@@ -64,6 +64,12 @@ spec:
     - name: DATA_PERSISTENCE
       value: ''
 
+    - name: TOTAL_CHAOS_DURATION
+      value: '60'
+
+    - name: CHAOS_INTERVAL
+      value: '15'
+
     - name: DEPLOY_TYPE
       value: 'deployment'
 


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- TOTAL_CHAOS_DURATION and CHAOS_INTERVAL values will now be taken from env's