### PR TITLE
refactor(yaml): Added total chaos duration env in container failure experiment in chaos chart

### DIFF
--- a/charts/openebs/openebs-target-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-container-failure/experiment.yaml
@@ -84,6 +84,9 @@ spec:
     - name: DEPLOY_TYPE
       value: 'deployment'
 
+    - name: TOTAL_CHAOS_DURATION
+      value: "60"
+      
     labels:
       name: openebs-target-container-failure
     configmaps:

--- a/charts/openebs/openebs-target-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-target-network-delay/experiment.yaml
@@ -59,7 +59,7 @@ spec:
     - name: NETWORK_DELAY
       value: '60000' # in milliseconds
 
-    - name: CHAOS_DURATION
+    - name: TOTAL_CHAOS_DURATION
       value: '60000' # in milliseconds
             
     - name: LIVENESS_APP_LABEL

--- a/charts/openebs/openebs-target-network-loss/experiment.yaml
+++ b/charts/openebs/openebs-target-network-loss/experiment.yaml
@@ -59,7 +59,7 @@ spec:
     - name: NETWORK_PACKET_LOSS_PERCENTAGE
       value: '100' # in percentage
 
-    - name: CHAOS_DURATION
+    - name: TOTAL_CHAOS_DURATION
       value: '240000' # in milliseconds
 
     - name: LIVENESS_APP_LABEL


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- Added the env in target container failure experiment.
- modified the chaos duration env in target nw delay and loss experiment