### PR TITLE
(Enhancement): Added/Removed permissions for pod-network-loss experiment

### DIFF
--- a/charts/generic/pod-network-loss/experiment.yaml
+++ b/charts/generic/pod-network-loss/experiment.yaml
@@ -8,6 +8,7 @@ metadata:
   version: 0.1.5
 spec:
   definition:
+    scope: Namespaced
     permissions:
     - apiGroups:
       - ""

--- a/charts/generic/pod-network-loss/experiment.yaml
+++ b/charts/generic/pod-network-loss/experiment.yaml
@@ -9,24 +9,22 @@ metadata:
 spec:
   definition:
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
+    - apiGroups:
+      - ""
+      - "batch"
+      - "litmuschaos.io"
       resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
+      - "jobs"
+      - "pods"
+      - "chaosengines"
+      - "chaosexperiments"
+      - "chaosresults"
       verbs:
-        - "*"
+      - "get"
+      - "list"
+      - "patch"
+      - "create"
+      - "delete"
     image: "litmuschaos/ansible-runner:ci"
     args:
     - -c


### PR DESCRIPTION
This PR enhances permissions needed by a service account used by the `pod-network-loss` experiment.

Signed-off-by: sanjay1611 <sanjay.nathani@mayadata.io>