### PR TITLE
(feat): Added TOTAL_CHAOS_DURATION ENV in drain-node chart

### DIFF
--- a/charts/generic/drain-node/experiment.yaml
+++ b/charts/generic/drain-node/experiment.yaml
@@ -45,6 +45,9 @@ spec:
     - name: APP_NODE
       value: ''
 
+    - name: TOTAL_CHAOS_DURATION
+      value: '60'
+
     - name: LIVENESS_APP_NAMESPACE
       value: '' 
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Added `TOTAL_CHAOS_DURATION` ENV in drain node chart
- fixes: litmuschaos/litmus#1067