### PR TITLE
(Enhancement): Remove unnecessary permissions and resources for DISK-LOSS experiment

### DIFF
--- a/charts/generic/disk-loss/experiment.yaml
+++ b/charts/generic/disk-loss/experiment.yaml
@@ -16,6 +16,7 @@ spec:
           - "litmuschaos.io"
         resources:
           - "jobs"
+          - "pods"
           - "secrets"
           - "chaosengines"
           - "chaosexperiments"

--- a/charts/generic/disk-loss/experiment.yaml
+++ b/charts/generic/disk-loss/experiment.yaml
@@ -7,23 +7,25 @@ metadata:
   name: disk-loss
   version: 0.1.2
 spec:
-  permissions:
-    apiGroups:
-      - ""
-      - "apps"
-      - "batch"
-      - "litmuschaos.io"
-    resources:
-      - "deployments"
-      - "statefulsets"
-      - "jobs"
-      - "pods"
-      - "chaosengines"
-      - "chaosexperiments"
-      - "chaosresults"
-    verbs:
-      - "*"
   definition:
+    scope: Cluster
+    permissions:
+      - apiGroups:
+          - ""
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "jobs"
+          - "secrets"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "delete"
     image: "litmuschaos/ansible-runner:ci"
     args:
     - -c


### PR DESCRIPTION
- Unnecessary permissions for disk-loss experiment should be removed.
- Remove unnecessary resources also.
Fixes https://github.com/litmuschaos/litmus/issues/1073

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>