### PR TITLE
(fix): convert contents of permissions into array elements in pod-cpu-hog experiment

### DIFF
--- a/charts/generic/pod-cpu-hog/experiment.yaml
+++ b/charts/generic/pod-cpu-hog/experiment.yaml
@@ -10,23 +10,22 @@ spec:
   definition:
     scope: Namespaced
     permissions:
-      apiGroups:
-        - ""
-        - "batch"
-        - "litmuschaos.io"
-      resources:
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-      verbs:
-        - "create"
-        - "list"
-        - "get"
-        - "patch"
-        - "delete"
+      - apiGroups:
+          - ""
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "jobs"
+          - "pods"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "delete"
     image: "litmuschaos/ansible-runner:ci"
     args:
     - -c


### PR DESCRIPTION
- Make the value of the `spec.definition.permissions` in pod-cpu-hog experiment to array
- Remove permissions to unwanted resources (pods/exec) 

fixes #99 

Signed-off-by: ksatchit <ksatchit@mayadata.io>