### PR TITLE
(feat): Adding minimal permissions in kafka broker pod failure

### DIFF
--- a/charts/generic/container-kill/experiment.yaml
+++ b/charts/generic/container-kill/experiment.yaml
@@ -42,7 +42,7 @@ spec:
     - name: TARGET_CONTAINER
       value: ''
 
-    # It only supported pumba
+    # It only supports pumba
     - name: LIB
       value: 'pumba'
 

--- a/charts/generic/cpu-hog/experiment.yaml
+++ b/charts/generic/cpu-hog/experiment.yaml
@@ -5,7 +5,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: cpu-hog
-  version: 0.0.5
+  version: 0.1.5
 spec:
   definition:
     scope: Cluster

--- a/charts/generic/disk-fill/experiment.yaml
+++ b/charts/generic/disk-fill/experiment.yaml
@@ -44,7 +44,7 @@ spec:
       value: ''
     
     - name: FILL_PERCENTAGE
-      value: ''
+      value: '80'
 
     - name: TOTAL_CHAOS_DURATION
       value: '60'

--- a/charts/generic/disk-loss/experiment.yaml
+++ b/charts/generic/disk-loss/experiment.yaml
@@ -46,7 +46,7 @@ spec:
     - name: CHAOS_NAMESPACE
       value: ''
         
-   # Only GCP is supported
+   # It supports GCP and AWS
     - name: CLOUD_PLATFORM
       value: 'GCP'
 

--- a/charts/kafka/kafka-broker-pod-failure/experiment.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/experiment.yaml
@@ -8,26 +8,36 @@ metadata:
   version: 0.1.3
 spec:
   definition:
+    scope: Cluster
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "statefulsets"
+          - "deployments"
+          - "configmaps"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "get"
+          - "delete"
+          - "list"
+          - "patch"
+      - apiGroups:
+          - ""
+        resources: 
+          - "nodes"
+        verbs :
+          - "get"
+          - "list"
     image: "litmuschaos/ansible-runner:ci"
     args:
     - -c
@@ -94,7 +104,7 @@ spec:
       value: ''
 
     ## env var that describes the library used to execute the chaos
-    ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+    ## default: litmus. Supported values: litmus, powerfulseal
     - name: LIB
       value: 'litmus'
  


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding permission and scope for kafka broker pod failure chart

- Fixes : litmuschaos/litmus#1099