### PR TITLE
(feat): Adding minimal permissions in kafka broker disk failure

### DIFF
--- a/charts/kafka/kafka-broker-disk-failure/experiment.yaml
+++ b/charts/kafka/kafka-broker-disk-failure/experiment.yaml
@@ -8,26 +8,28 @@ metadata:
   version: 0.1.3
 spec:
   definition:
+    scope: Cluster
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "statefulsets"
+          - "secrets"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "delete"
+          - "get"
+          - "list"
+          - "patch"
     image: "litmuschaos/ansible-runner:ci"
     args:
     - -c


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Fixes: litmuschaos/litmus#1103

- Adding minimal permissions and scope in kafka broker disk failure chart