### PR TITLE
(refactor): convert permission to array from object

### DIFF
--- a/charts/openebs/openebs-pool-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-container-failure/experiment.yaml
@@ -11,28 +11,28 @@ metadata:
   version: 0.1.4
 spec:
   permissions:
-    apiGroups:
-      - ""
-      - "extensions"
-      - "apps"
-      - "batch"
-      - "litmuschaos.io"
-      - "openebs.io"
-    resources:
-      - "daemonsets"
-      - "statefulsets"
-      - "deployments"
-      - "replicasets"
-      - "jobs"
-      - "pods"
-      - "pods/exec"
-      - "chaosengines"
-      - "chaosexperiments"
-      - "chaosresults"
-      - "persistentvolumeclaims"
-      - "cstorvolumereplicas"
-    verbs:
-      - "*"
+    - apiGroups:
+        - ""
+        - "extensions"
+        - "apps"
+        - "batch"
+        - "litmuschaos.io"
+        - "openebs.io"
+      resources:
+        - "daemonsets"
+        - "statefulsets"
+        - "deployments"
+        - "replicasets"
+        - "jobs"
+        - "pods"
+        - "pods/exec"
+        - "chaosengines"
+        - "chaosexperiments"
+        - "chaosresults"
+        - "persistentvolumeclaims"
+        - "cstorvolumereplicas"
+      verbs:
+        - "*"
   definition:
     image: "litmuschaos/ansible-runner:latest"
     args:

--- a/charts/openebs/openebs-pool-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-pod-failure/experiment.yaml
@@ -12,28 +12,28 @@ metadata:
 spec:
   definition:
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-        - "openebs.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-        - "persistentvolumeclaims"
-        - "cstorvolumereplicas"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "extensions"
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+          - "openebs.io"
+        resources:
+          - "daemonsets"
+          - "statefulsets"
+          - "deployments"
+          - "replicasets"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+          - "persistentvolumeclaims"
+          - "cstorvolumereplicas"
+        verbs:
+          - "*"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c

--- a/charts/openebs/openebs-target-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-container-failure/experiment.yaml
@@ -12,30 +12,30 @@ metadata:
 spec:
   definition:
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-        - "openebs.io"
-        - "storage.k8s.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-        - "persistentvolumeclaims"
-        - "storageclasses"
-        - "persistentvolumes"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "extensions"
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+          - "openebs.io"
+          - "storage.k8s.io"
+        resources:
+          - "daemonsets"
+          - "statefulsets"
+          - "deployments"
+          - "replicasets"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+          - "persistentvolumeclaims"
+          - "storageclasses"
+          - "persistentvolumes"
+        verbs:
+          - "*"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c

--- a/charts/openebs/openebs-target-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-target-network-delay/experiment.yaml
@@ -11,30 +11,30 @@ metadata:
 spec:
   definition:
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-        - "openebs.io"
-        - "storage.k8s.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-        - "persistentvolumeclaims"
-        - "storageclasses"
-        - "persistentvolumes"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "extensions"
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+          - "openebs.io"
+          - "storage.k8s.io"
+        resources:
+          - "daemonsets"
+          - "statefulsets"
+          - "deployments"
+          - "replicasets"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+          - "persistentvolumeclaims"
+          - "storageclasses"
+          - "persistentvolumes"
+        verbs:
+          - "*"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c

--- a/charts/openebs/openebs-target-network-loss/experiment.yaml
+++ b/charts/openebs/openebs-target-network-loss/experiment.yaml
@@ -11,30 +11,30 @@ metadata:
 spec:
   definition:
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-        - "openebs.io"
-        - "storage.k8s.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-        - "persistentvolumeclaims"
-        - "storageclasses"
-        - "persistentvolumes"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "extensions"
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+          - "openebs.io"
+          - "storage.k8s.io"
+        resources:
+          - "daemonsets"
+          - "statefulsets"
+          - "deployments"
+          - "replicasets"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+          - "persistentvolumeclaims"
+          - "storageclasses"
+          - "persistentvolumes"
+        verbs:
+          - "*"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c

--- a/charts/openebs/openebs-target-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-pod-failure/experiment.yaml
@@ -12,30 +12,30 @@ metadata:
 spec:
   definition:
     permissions:
-      apiGroups:
-        - ""
-        - "extensions"
-        - "apps"
-        - "batch"
-        - "litmuschaos.io"
-        - "openebs.io"
-        - "storage.k8s.io"
-      resources:
-        - "daemonsets"
-        - "statefulsets"
-        - "deployments"
-        - "replicasets"
-        - "jobs"
-        - "pods"
-        - "pods/exec"
-        - "chaosengines"
-        - "chaosexperiments"
-        - "chaosresults"
-        - "persistentvolumeclaims"
-        - "storageclasses"
-        - "persistentvolumes"
-      verbs:
-        - "*"
+      - apiGroups:
+          - ""
+          - "extensions"
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+          - "openebs.io"
+          - "storage.k8s.io"
+        resources:
+          - "daemonsets"
+          - "statefulsets"
+          - "deployments"
+          - "replicasets"
+          - "jobs"
+          - "pods"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+          - "persistentvolumeclaims"
+          - "storageclasses"
+          - "persistentvolumes"
+        verbs:
+          - "*"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Convert permission field in openebs charts to array from chart. The latest chaos-experiments_crd is updated so it is unable to apply the openebs charts.