### PR TITLE
(feat): Add minimal permission in openebs target container failure chart

### DIFF
--- a/charts/openebs/openebs-target-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-container-failure/experiment.yaml
@@ -11,31 +11,34 @@ metadata:
   version: 0.1.6
 spec:
   definition:
+    scope: Cluster
     permissions:
       - apiGroups:
           - ""
-          - "extensions"
           - "apps"
           - "batch"
           - "litmuschaos.io"
-          - "openebs.io"
           - "storage.k8s.io"
         resources:
           - "daemonsets"
-          - "statefulsets"
-          - "deployments"
-          - "replicasets"
           - "jobs"
           - "pods"
           - "pods/exec"
-          - "chaosengines"
-          - "chaosexperiments"
-          - "chaosresults"
+          - "configmaps"
+          - "secrets"
           - "persistentvolumeclaims"
           - "storageclasses"
           - "persistentvolumes"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
         verbs:
-          - "*"
+          - "create"
+          - "delete"
+          - "get"
+          - "list"
+          - "patch"
+          - "update"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c

--- a/charts/openebs/openebs-target-container-failure/openebs-target-container-failure.chartserviceversion.yaml
+++ b/charts/openebs/openebs-target-container-failure/openebs-target-container-failure.chartserviceversion.yaml
@@ -29,7 +29,7 @@ spec:
     - name: Source Code
       url: https://github.com/litmuschaos/litmus/tree/master/experiments/openebs/openebs-target-container-failure
     - name: Documentation
-      url: https://docs.litmuschaos.io/docs/openebs-target-container-kill/
+      url: https://docs.litmuschaos.io/docs/openebs-target-container-failure/
   icon:
     - url: ""
       mediatype: ""


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Fixes: litmuschaos/litmus#1131

- Added minimal permission in openebs target container failure chart