### PR TITLE
(feat): Adding minimal permission in openebs-target-pod-failure chart

### DIFF
--- a/charts/openebs/openebs-target-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-pod-failure/experiment.yaml
@@ -11,6 +11,7 @@ metadata:
   version: 0.1.6
 spec:
   definition:
+    scope: Cluster
     permissions:
       - apiGroups:
           - ""
@@ -18,16 +19,15 @@ spec:
           - "apps"
           - "batch"
           - "litmuschaos.io"
-          - "openebs.io"
           - "storage.k8s.io"
         resources:
-          - "daemonsets"
-          - "statefulsets"
           - "deployments"
-          - "replicasets"
           - "jobs"
           - "pods"
           - "pods/exec"
+          - "configmaps"
+          - "secrets"
+          - "services"
           - "chaosengines"
           - "chaosexperiments"
           - "chaosresults"
@@ -35,7 +35,19 @@ spec:
           - "storageclasses"
           - "persistentvolumes"
         verbs:
-          - "*"
+          - "create"
+          - "get"
+          - "delete"
+          - "list"
+          - "patch"
+          - "update"
+        - apiGroups:
+          - ""
+          resources:
+          - "nodes"
+          verbs:
+          - "get"
+          - "list"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding minimal permissions in openebs-target-pod-failure experiment

-  Fixes: litmuschaos/litmus#1142