### PR TITLE
(feat): Adding minimal permission in openebs-pool-container-failure chart

### DIFF
--- a/charts/openebs/openebs-pool-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-container-failure/experiment.yaml
@@ -11,6 +11,7 @@ metadata:
   version: 0.1.6
 spec:
   definition:
+    scope: Cluster
     permissions:
       - apiGroups:
           - ""
@@ -19,21 +20,27 @@ spec:
           - "batch"
           - "litmuschaos.io"
           - "openebs.io"
+          - "storage.k8s.io"
         resources:
           - "daemonsets"
-          - "statefulsets"
-          - "deployments"
           - "replicasets"
           - "jobs"
           - "pods"
           - "pods/exec"
+          - "configmaps"
+          - "secrets"
+          - "persistentvolumeclaims"
+          - "cstorvolumereplicas"
           - "chaosengines"
           - "chaosexperiments"
           - "chaosresults"
-          - "persistentvolumeclaims"
-          - "cstorvolumereplicas"
         verbs:
-          - "*"
+          - "create"
+          - "get"
+          - "delete"
+          - "list"
+          - "patch"
+          - "update"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding minimal permissions in openebs-pool-container-failure experiment

- Fixes: litmuschaos/litmus#1147