### PR TITLE
(feat): Adding minimal permission in openebs-target-network-delay chart

### DIFF
--- a/charts/openebs/openebs-target-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-target-network-delay/experiment.yaml
@@ -10,6 +10,7 @@ metadata:
   version: 0.1.7
 spec:
   definition:
+    scope: Cluster
     permissions:
       - apiGroups:
           - ""
@@ -17,24 +18,27 @@ spec:
           - "apps"
           - "batch"
           - "litmuschaos.io"
-          - "openebs.io"
           - "storage.k8s.io"
         resources:
-          - "daemonsets"
-          - "statefulsets"
-          - "deployments"
-          - "replicasets"
           - "jobs"
           - "pods"
+          - "services"
           - "pods/exec"
-          - "chaosengines"
-          - "chaosexperiments"
-          - "chaosresults"
+          - "configmaps"
+          - "secrets"
           - "persistentvolumeclaims"
           - "storageclasses"
           - "persistentvolumes"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
         verbs:
-          - "*"
+          - "create"
+          - "get"
+          - "delete"
+          - "list"
+          - "patch"
+          - "update"
     image: "litmuschaos/ansible-runner:latest"
     args:
     - -c


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding minimal permissions in openebs-target-network-delay experiment

- Fixes: litmuschaos/litmus#1153