### PR TITLE
(refactor): Changing image tag for node-cpu-hog experiment

### DIFF
--- a/charts/generic/node-cpu-hog/experiment.yaml
+++ b/charts/generic/node-cpu-hog/experiment.yaml
@@ -37,7 +37,7 @@ spec:
         verbs :
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:ci"
     args:
     - -c
     - ansible-playbook ./experiments/generic/node_cpu_hog/node_cpu_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Changing image tag of node-cpu-hog chart to `ci` because the name change of this experiment from `cpu-hog` to `node-cpu-hog` is not updated in `latest` image