### PR TITLE
(feat): fixing the default value in auxiliaryAppInfo of node-cpu-hog exp

### DIFF
--- a/charts/generic/node-cpu-hog/engine.yaml
+++ b/charts/generic/node-cpu-hog/engine.yaml
@@ -9,7 +9,7 @@ spec:
   # It can be active/stop
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 'ns1:name=percona,ns2:run=nginx'
+  auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
     applabel: 'app=nginx'


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>
- fixing the default value in auxiliaryAppInfo of node-cpu-hog exp