### PR TITLE
(chore) update experiment-runner image to 1.1.0

### DIFF
--- a/charts/coredns/coredns-pod-delete/experiment.yaml
+++ b/charts/coredns/coredns-pod-delete/experiment.yaml
@@ -27,7 +27,7 @@ spec:
         - "create"
         - "update"
         - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/coredns/pod_delete/pod_delete_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/container-kill/experiment.yaml
+++ b/charts/generic/container-kill/experiment.yaml
@@ -29,7 +29,7 @@ spec:
           - "update"
           - "patch"
           - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/container_kill/container_kill_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/disk-fill/experiment.yaml
+++ b/charts/generic/disk-fill/experiment.yaml
@@ -30,7 +30,7 @@ spec:
           - "patch"
           - "update"
           - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/disk_fill/disk_fill_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/disk-loss/experiment.yaml
+++ b/charts/generic/disk-loss/experiment.yaml
@@ -28,7 +28,7 @@ spec:
           - "patch"
           - "update"
           - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/disk_loss/disk_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/node-cpu-hog/experiment.yaml
+++ b/charts/generic/node-cpu-hog/experiment.yaml
@@ -37,7 +37,7 @@ spec:
         verbs :
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/node_cpu_hog/node_cpu_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/node-drain/experiment.yaml
+++ b/charts/generic/node-drain/experiment.yaml
@@ -39,7 +39,7 @@ spec:
           - "get"
           - "list"
           - "patch"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/node_drain/node_drain_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/pod-cpu-hog/experiment.yaml
+++ b/charts/generic/pod-cpu-hog/experiment.yaml
@@ -27,7 +27,7 @@ spec:
           - "patch"
           - "update"
           - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_cpu_hog/pod_cpu_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/pod-delete/experiment.yaml
+++ b/charts/generic/pod-delete/experiment.yaml
@@ -37,7 +37,7 @@ spec:
         verbs :
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_delete/pod_delete_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/pod-network-corruption/experiment.yaml
+++ b/charts/generic/pod-network-corruption/experiment.yaml
@@ -27,7 +27,7 @@ spec:
           - "patch"
           - "update"
           - "get"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_network_corruption/pod_network_corruption_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/pod-network-latency/experiment.yaml
+++ b/charts/generic/pod-network-latency/experiment.yaml
@@ -27,7 +27,7 @@ spec:
           - "patch"
           - "update"
           - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_network_latency/pod_network_latency_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/generic/pod-network-loss/experiment.yaml
+++ b/charts/generic/pod-network-loss/experiment.yaml
@@ -27,7 +27,7 @@ spec:
       - "create"
       - "update"
       - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/generic/pod_network_loss/pod_network_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kafka/kafka-broker-disk-failure/experiment.yaml
+++ b/charts/kafka/kafka-broker-disk-failure/experiment.yaml
@@ -30,7 +30,7 @@ spec:
           - "get"
           - "list"
           - "patch"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/kafka/kafka-broker-disk-failure/kafka-broker-disk-failure-ansible-logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/kafka/kafka-broker-pod-failure/experiment.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/experiment.yaml
@@ -38,7 +38,7 @@ spec:
         verbs :
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/kafka/kafka-broker-pod-failure/kafka-broker-pod-failure-ansible-logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-control-plane-validation/experiment.yaml
+++ b/charts/openebs/openebs-control-plane-validation/experiment.yaml
@@ -41,7 +41,7 @@ spec:
           - "get"
           - "list"
       
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-control-plane-validation/openebs_control_plane_validation_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-pool-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-container-failure/experiment.yaml
@@ -41,7 +41,7 @@ spec:
           - "list"
           - "patch"
           - "update"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-pool-container-failure/openebs_pool_container_failure_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-pool-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-pool-network-delay/experiment.yaml
@@ -43,7 +43,7 @@ spec:
           - "patch"
           - "update"
           - "delete"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-pool-network-delay/openebs_pool_network_delay_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-pool-network-loss/experiment.yaml
+++ b/charts/openebs/openebs-pool-network-loss/experiment.yaml
@@ -43,7 +43,7 @@ spec:
           - "list"
           - "patch"
           - "update"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-pool-network-loss/openebs_pool_network_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-pool-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-pod-failure/experiment.yaml
@@ -48,7 +48,7 @@ spec:
         verbs:
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-pool-pod-failure/openebs_pool_pod_failure_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-target-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-container-failure/experiment.yaml
@@ -39,7 +39,7 @@ spec:
           - "list"
           - "patch"
           - "update"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-target-container-failure/openebs_target_container_failure_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-target-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-target-network-delay/experiment.yaml
@@ -39,7 +39,7 @@ spec:
           - "list"
           - "patch"
           - "update"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-target-network-delay/openebs_target_network_delay_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-target-network-loss/experiment.yaml
+++ b/charts/openebs/openebs-target-network-loss/experiment.yaml
@@ -39,7 +39,7 @@ spec:
           - "list"
           - "patch"
           - "update"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-target-network-loss/openebs_target_network_loss_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/charts/openebs/openebs-target-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-pod-failure/experiment.yaml
@@ -48,7 +48,7 @@ spec:
         verbs:
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:latest"
+    image: "litmuschaos/ansible-runner:1.1.0"
     args:
     - -c
     - ansible-playbook ./experiments/openebs/openebs-target-pod-failure/openebs_target_pod_failure_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0

--- a/scripts/version/push.sh
+++ b/scripts/version/push.sh
@@ -6,7 +6,7 @@ setup_git() {
 }
 
 commit_updated_changes() {
-  git checkout master
+  git checkout v1.1.x
   git status
   git add .
   git commit --message " $TRAVIS_BUILD_NUMBER: version upgraded for chaos-charts"
@@ -15,7 +15,7 @@ commit_updated_changes() {
 
 upload_files() {
   git remote -v
-  git push origin master
+  git push origin v1.1.x
 }
 
 setup_git


### PR DESCRIPTION
### Updates to 1.1.x charts

- Set experiment (ansible-runner) images to 1.1.0 for charts in 1.1.x branch
- Ensure autoversion & aggregated experiments yaml commit happens in v.1.1x branch

Signed-off-by: ksatchit <ksatchit@mayadata.io>