### PR TITLE
Adding Chaostoolkit pattern via leveraging litmus on kubernetes - Charts 

### DIFF
--- a/charts/chaostoolkit/k8-pod-delete/engine.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/engine.yaml
@@ -8,16 +8,11 @@ spec:
     appns: 'default'
     applabel: 'app=nginx'
     appkind: 'deployment'
-  # It can be true/false
   annotationCheck: 'true'
-  # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx
-  auxiliaryAppInfo: ''
   chaosServiceAccount: k8-pod-delete-sa
   monitoring: false
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
+  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:
@@ -33,4 +28,4 @@ spec:
             - name: APP_ENDPOINT
               value: 'localhost'
             - name: FILE
-              value: 'experiment.json'
+              value: 'pod-app-kill-count.json'

--- a/charts/chaostoolkit/k8-pod-delete/engine.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/engine.yaml
@@ -1,0 +1,36 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  appinfo:
+    appns: 'default'
+    applabel: 'app=nginx'
+    appkind: 'deployment'
+  # It can be true/false
+  annotationCheck: 'true'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: k8-pod-delete-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: k8-pod-delete
+      spec:
+        components:
+          env:
+            # set chaos namespace
+            - name: NAME_SPACE
+              value: 'default'
+            # set chaos label name
+            - name: LABEL_NAME
+              value: 'nginx'
+            # pod endpoint 
+            - name: APP_ENDPOINT
+              value: 'localhost'
+            - name: FILE
+              value: 'experiment.json'

--- a/charts/chaostoolkit/k8-pod-delete/experiment.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/experiment.yaml
@@ -1,0 +1,60 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Deletes a pod belonging to a deployment/statefulset/daemonset
+kind: ChaosExperiment
+metadata:
+  name: k8-pod-delete
+  version: 0.0.1
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      - apiGroups:
+          - ""
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "deployments"
+          - "jobs"
+          - "pods"
+          - "configmaps"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+      - apiGroups:
+          - ""
+        resources: 
+          - "nodes"
+        verbs :
+          - "get"
+          - "list"
+    image: "litmuschaos/chaostolkit:latest"
+    args:
+    - -c
+    - python k8_wrapper.py; exit 0
+    command:
+    - /bin/bash
+    env:
+
+    - name: NAME_SPACE
+      value: 'default'
+
+    - name: LABEL_NAME
+      value: 'nginx'
+
+    - name: APP_ENDPOINT
+      value: 'localhost'
+
+    - name: LIB
+      value: ''    
+    labels:
+      name: k8-pod-delete

--- a/charts/chaostoolkit/k8-pod-delete/experiment.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/experiment.yaml
@@ -30,31 +30,30 @@ spec:
           - "patch"
           - "update"
           - "delete"
-      - apiGroups:
-          - ""
-        resources: 
-          - "nodes"
-        verbs :
-          - "get"
-          - "list"
-    image: "litmuschaos/chaostolkit:latest"
+    image: "litmuschaos/chaostoolkit:latest"
     args:
     - -c
-    - python k8_wrapper.py; exit 0
+    - python /app/data/k8_wrapper.py; exit 0
     command:
     - /bin/bash
     env:
+    - name: CHAOSTOOLKIT_IN_POD
+      value: 'true'
+
+    - name: FILE
+      value: 'pod-app-kill-count.json'
 
     - name: NAME_SPACE
-      value: 'default'
+      value: ''
 
     - name: LABEL_NAME
-      value: 'nginx'
+      value: ''
 
     - name: APP_ENDPOINT
-      value: 'localhost'
+      value: ''
 
-    - name: LIB
-      value: ''    
+    - name: PERCENTAGE
+      value: '50'
+
     labels:
       name: k8-pod-delete

--- a/charts/chaostoolkit/k8-pod-delete/k8-pod-delete.chartserviceversion.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/k8-pod-delete.chartserviceversion.yaml
@@ -11,8 +11,7 @@ metadata:
 spec:
   displayName: k8-pod-delete
   categoryDescription: |
-    K8 Pod delete contains chaos to disrupt state of kubernetes resources. Experiments can inject random pod delete failures against specified application.
- 
+    K8 Pod delete contains chaos to disrupt state of kubernetes resources. It uses chaostoolkit to inject random pod delete failures against specified applications
   keywords:
     - Kubernetes
     - State 
@@ -31,7 +30,7 @@ spec:
     - name: Documentation
       url: https://docs.litmuschaos.io/docs/k8-pod-delete/
     - name: Video
-      url: https://www.youtube.com/watch?v=X3JvY_58V9A
+      url: '' 
   icon:
     - url: 
       mediatype: ""

--- a/charts/chaostoolkit/k8-pod-delete/k8-pod-delete.chartserviceversion.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/k8-pod-delete.chartserviceversion.yaml
@@ -1,0 +1,38 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: k8-pod-delete
+  version: 0.0.1
+  annotations:
+    categories: Kubernetes
+    vendor: CNCF
+    createdAt: 2020-02-24T10:28:08Z
+    support: https://slack.kubernetes.io/
+spec:
+  displayName: k8-pod-delete
+  categoryDescription: |
+    K8 Pod delete contains chaos to disrupt state of kubernetes resources. Experiments can inject random pod delete failures against specified application.
+ 
+  keywords:
+    - Kubernetes
+    - State 
+  platforms:
+     - Minikube
+  maturity: alpha
+  maintainers:
+    - name: sumit
+      email: sumit_nagal@intuit.com
+  minKubeVersion: 1.12.0
+  provider:
+    name: Intuit
+  links:
+    - name: Source Code
+      url: https://github.com/litmuschaos/litmus/tree/master/experiments/chaostoolkit/k8-pod_delete
+    - name: Documentation
+      url: https://docs.litmuschaos.io/docs/k8-pod-delete/
+    - name: Video
+      url: https://www.youtube.com/watch?v=X3JvY_58V9A
+  icon:
+    - url: 
+      mediatype: ""
+  chaosexpcrdlink: https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/chaostoolkit/k8-pod-delete/experiment.yaml

--- a/charts/chaostoolkit/k8-pod-delete/rbac.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8-pod-delete-sa
+  namespace: default
+  labels:
+    name: k8-pod-delete-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: k8-pod-delete-sa
+  namespace: default
+  labels:
+    name: k8-pod-delete-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","deployments","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs : ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: k8-pod-delete-sa
+  namespace: default
+  labels:
+    name: k8-pod-delete-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8-pod-delete-sa
+subjects:
+- kind: ServiceAccount
+  name: k8-pod-delete-sa
+  namespace: default
+


### PR DESCRIPTION
This PR is about, how can we invoke another framework build on opensource. We are talking about chaostoolkit, and this is a place holder where we will add enhance this as per our need. As we have many customizations as a security compliance requirement we need to use in this manner, we try to keep it generic so anyone can use it. here is the issue raised on this - litmuschaos/litmus#1204

In this, we are creating the reference charts, which could use or reference while running chaos.