### PR TITLE
feat(charts): Adding chaos charts for node-memory-hog experiment

### DIFF
--- a/charts/generic/generic.chartserviceversion.yaml
+++ b/charts/generic/generic.chartserviceversion.yaml
@@ -23,6 +23,7 @@ spec:
     - node-cpu-hog
     - disk-loss
     - disk-fill
+    - node-memory-hog
 
   keywords:
     - Kubernetes

--- a/charts/generic/generic.package.yaml
+++ b/charts/generic/generic.package.yaml
@@ -30,3 +30,6 @@ experiments:
   - name: pod-network-corruption
     CSV: pod-network-corruption.chartserviceversion.yaml
     desc: "pod-network-corruption"
+  - name: node-memory-hog
+    CSV: node-memory-hog.chartserviceversion.yaml
+    desc: "node-memory-hog"

--- a/charts/generic/node-cpu-hog/experiment.yaml
+++ b/charts/generic/node-cpu-hog/experiment.yaml
@@ -19,7 +19,6 @@ spec:
           - "daemonsets"
           - "jobs"
           - "pods"
-          - "pods/exec"
           - "events"
           - "chaosengines"
           - "chaosexperiments"

--- a/charts/generic/node-cpu-hog/node-cpu-hog.chartserviceversion.yaml
+++ b/charts/generic/node-cpu-hog/node-cpu-hog.chartserviceversion.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   displayName: node-cpu-hog
   categoryDescription: |
-    Node CPU hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a cpu spike on a node where the application pod is scheduled.
-    - Causes (forced/graceful) cpu hog on a perticular node where the application deployment is available.
-    - After test the recovery should be manual of the application pod and node in case they are not in appropriate state.
- 
+    Node CPU hog contains chaos to disrupt the state of Kubernetes resources. Experiments can inject a CPU spike on a node where the application pod is scheduled.
+    - CPU hog on a particular node where the application deployment is available.
+    - After test, the recovery should be manual for the application pod and node in case they are not in an appropriate state.
+
   keywords:
     - Kubernetes
     - CPU

--- a/charts/generic/node-cpu-hog/node-cpu-hog.chartserviceversion.yaml
+++ b/charts/generic/node-cpu-hog/node-cpu-hog.chartserviceversion.yaml
@@ -11,14 +11,15 @@ metadata:
 spec:
   displayName: node-cpu-hog
   categoryDescription: |
-    Node CPU hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a cpu skipe on a node where the application pod is scheduled.
+    Node CPU hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a cpu spike on a node where the application pod is scheduled.
     - Causes (forced/graceful) cpu hog on a perticular node where the application deployment is available.
     - After test the recovery should be manual of the application pod and node in case they are not in appropriate state.
  
   keywords:
     - Kubernetes
     - CPU
-    - State 
+    - State
+    - Node
   platforms:
     - GKE
   maturity: alpha

--- a/charts/generic/node-cpu-hog/rbac.yaml
+++ b/charts/generic/node-cpu-hog/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
     name: node-cpu-hog-sa
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
-  resources: ["pods","daemonsets","jobs","pods/exec","events","chaosengines","chaosexperiments","chaosresults"]
+  resources: ["pods","jobs","events","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["create","list","get","patch","update","delete"]
 - apiGroups: [""]
   resources: ["nodes"]

--- a/charts/generic/node-memory-hog/engine.yaml
+++ b/charts/generic/node-memory-hog/engine.yaml
@@ -1,0 +1,38 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  # It can be true/false
+  annotationCheck: 'false'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ''
+  appinfo:
+    appns: 'default'
+    applabel: 'app=nginx'
+    appkind: 'deployment'
+  chaosServiceAccount: node-memory-hog-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-memory-hog
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+            ## specify the size as percent of total available memory (in percentage %)
+            ## default value 90%
+            - name: MEMORY_PERCENTAGE
+              value: '90'             
+            # set chaos platform as desired
+            - name: PLATFORM
+              value: 'GKE'
+            # chaos lib used to inject the chaos
+            - name: LIB
+              value: 'litmus'

--- a/charts/generic/node-memory-hog/experiment.yaml
+++ b/charts/generic/node-memory-hog/experiment.yaml
@@ -5,7 +5,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: node-memory-hog
-  version: 0.0.1
+  version: 0.1.0
 spec:
   definition:
     scope: Cluster
@@ -16,7 +16,6 @@ spec:
           - "apps"
           - "litmuschaos.io"
         resources:
-          - "daemonsets"
           - "jobs"
           - "pods"
           - "pods/log"
@@ -60,7 +59,7 @@ spec:
       value: 'GKE'
 
     - name: LIB
-      value: ''
+      value: 'litmus'
       
     labels:
       name: node-memory-hog

--- a/charts/generic/node-memory-hog/experiment.yaml
+++ b/charts/generic/node-memory-hog/experiment.yaml
@@ -1,0 +1,66 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Give a memory hog on a node belonging to a deployment
+kind: ChaosExperiment
+metadata:
+  name: node-memory-hog
+  version: 0.0.1
+spec:
+  definition:
+    scope: Cluster
+    permissions:
+      - apiGroups:
+          - ""
+          - "batch"
+          - "apps"
+          - "litmuschaos.io"
+        resources:
+          - "daemonsets"
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "events"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+      - apiGroups:
+          - ""
+        resources: 
+          - "nodes"
+        verbs :
+          - "get"
+          - "list"
+    image: "litmuschaos/ansible-runner:latest"
+    args:
+    - -c
+    - ansible-playbook ./experiments/generic/node_memory_hog/node_memory_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0
+    command:
+    - /bin/bash
+    env:
+
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: 'default'
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60'
+
+    # Period to wait before injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    - name: PLATFORM
+      value: 'GKE'
+
+    - name: LIB
+      value: ''
+      
+    labels:
+      name: node-memory-hog

--- a/charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
+++ b/charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
@@ -2,8 +2,8 @@ apiVersion: litmuchaos.io/v1alpha1
 kind: ChartServiceVersion
 metadata:
   createdAt: 2020-03-28T10:28:08Z
-  name: node-cpu-hog
-  version: 0.0.1
+  name: node-memory-hog
+  version: 0.1.0
   annotations:
     categories: Kubernetes
     vendor: CNCF
@@ -11,7 +11,7 @@ metadata:
 spec:
   displayName: node-memory-hog
   categoryDescription: |
-    Kubernetes Node memory hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a memory skipe on a node where the application pod is scheduled.
+    Kubernetes Node memory hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a memory spike on a node where the application pod is scheduled.
     - Causes (forced/graceful) Memory hog on a perticular node where the application deployment is available.
     - After test the recovery should be manual of the application pod and node in case they are not in appropriate state. The chances of such scenarios is when the memory percentance provided is greater than 100%.
  
@@ -19,12 +19,13 @@ spec:
     - Kubernetes
     - Memory
     - State 
+    - Node
   platforms:
     - GKE
   maturity: alpha
   chaosType: infra
   maintainers:
-    - name: udit
+    - name: Udit Gaurav
       email: udit.gaurav@mayadata.io
   minKubeVersion: 1.12.0
   provider:

--- a/charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
+++ b/charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
@@ -1,0 +1,38 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  createdAt: 2020-03-28T10:28:08Z
+  name: node-cpu-hog
+  version: 0.0.1
+  annotations:
+    categories: Kubernetes
+    vendor: CNCF
+    support: https://slack.kubernetes.io/
+spec:
+  displayName: node-memory-hog
+  categoryDescription: |
+    Kubernetes Node memory hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a memory skipe on a node where the application pod is scheduled.
+    - Causes (forced/graceful) Memory hog on a perticular node where the application deployment is available.
+    - After test the recovery should be manual of the application pod and node in case they are not in appropriate state. The chances of such scenarios is when the memory percentance provided is greater than 100%.
+ 
+  keywords:
+    - Kubernetes
+    - Memory
+    - State 
+  platforms:
+    - GKE
+  maturity: alpha
+  chaosType: infra
+  maintainers:
+    - name: udit
+      email: udit.gaurav@mayadata.io
+  minKubeVersion: 1.12.0
+  provider:
+    name: Mayadata
+  links:
+    - name: Source Code
+      url: https://github.com/litmuschaos/litmus/tree/master/experiments/generic/node_memory_hog
+    - name: Documentation
+      url: https://docs.litmuschaos.io/docs/node-memory-hog/
+    - name: Video
+      url:

--- a/charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
+++ b/charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   displayName: node-memory-hog
   categoryDescription: |
-    Kubernetes Node memory hog contains chaos to disrupt state of kubernetes resources. Experiments can inject a memory spike on a node where the application pod is scheduled.
-    - Causes (forced/graceful) Memory hog on a perticular node where the application deployment is available.
-    - After test the recovery should be manual of the application pod and node in case they are not in appropriate state. The chances of such scenarios is when the memory percentance provided is greater than 100%.
- 
+    Kubernetes Node memory hog contains chaos to disrupt the state of Kubernetes resources. Experiments can inject a memory spike on a node where the application pod is scheduled.
+    - Memory hog on a particular node where the application deployment is available.
+    - After the test, the recovery should be manual for the application pod and node in case they are not in an appropriate state. 
+
   keywords:
     - Kubernetes
     - Memory
@@ -37,3 +37,7 @@ spec:
       url: https://docs.litmuschaos.io/docs/node-memory-hog/
     - name: Video
       url:
+  icon:
+    - url: ""
+      mediatype: ""
+  chaosexpcrdlink: https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-memory-hog/experiment.yaml

--- a/charts/generic/node-memory-hog/rbac.yaml
+++ b/charts/generic/node-memory-hog/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
     name: node-memory-hog-sa
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
-  resources: ["pods","daemonsets","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
+  resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["create","list","get","patch","update","delete"]
 - apiGroups: [""]
   resources: ["nodes"]

--- a/charts/generic/node-memory-hog/rbac.yaml
+++ b/charts/generic/node-memory-hog/rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-memory-hog-sa
+  namespace: default
+  labels:
+    name: node-memory-hog-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: node-memory-hog-sa
+  labels:
+    name: node-memory-hog-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","daemonsets","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs : ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: node-memory-hog-sa
+  labels:
+    name: node-memory-hog-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-memory-hog-sa
+subjects:
+- kind: ServiceAccount
+  name: node-memory-hog-sa
+  namespace: default


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

**_This PR is for:_**

- Adding chaos charts for node-memory-hog experiment
- Removing extra permissions from node CPU hog experiment
**_Files Added:_**

```
charts/generic/node-memory-hog/engine.yaml
charts/generic/node-memory-hog/experiment.yaml
charts/generic/node-memory-hog/node-memory-hog.chartserviceversion.yaml
charts/generic/node-memory-hog/rbac.yaml
```