### PR TITLE
charts(pod-memory-hog): Add Chaos Chart for pod memory hog experiment

### DIFF
--- a/charts/generic/generic.chartserviceversion.yaml
+++ b/charts/generic/generic.chartserviceversion.yaml
@@ -24,6 +24,7 @@ spec:
     - disk-loss
     - disk-fill
     - node-memory-hog
+    - pod-memory-hog
 
   keywords:
     - Kubernetes
@@ -32,6 +33,8 @@ spec:
     - Pod
     - Disk
     - Network
+    - CPU
+    - Memory
   maintainers:
     - name: ksatchit
       email: karthik.s@mayadata.io

--- a/charts/generic/generic.package.yaml
+++ b/charts/generic/generic.package.yaml
@@ -33,3 +33,6 @@ experiments:
   - name: node-memory-hog
     CSV: node-memory-hog.chartserviceversion.yaml
     desc: "node-memory-hog"
+  - name: pod-cpu-hog
+    CSV: pod-cpu-hog.chartserviceversion.yaml
+    desc: "pod-cpu-hog"    

--- a/charts/generic/generic.package.yaml
+++ b/charts/generic/generic.package.yaml
@@ -33,6 +33,6 @@ experiments:
   - name: node-memory-hog
     CSV: node-memory-hog.chartserviceversion.yaml
     desc: "node-memory-hog"
-  - name: pod-cpu-hog
-    CSV: pod-cpu-hog.chartserviceversion.yaml
-    desc: "pod-cpu-hog"    
+  - name: pod-memory-hog
+    CSV: pod-memory-hog.chartserviceversion.yaml
+    desc: "pod-memory-hog"   

--- a/charts/generic/pod-memory-hog/engine.yaml
+++ b/charts/generic/pod-memory-hog/engine.yaml
@@ -1,0 +1,38 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  # It can be true/false
+  annotationCheck: 'true'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ''
+  appinfo:
+    appns: 'default'
+    applabel: 'app=nginx'
+    appkind: 'deployment'
+  chaosServiceAccount: pod-memory-hog-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: pod-memory-hog
+      spec:
+        components:
+          env:
+            # Provide name of target container
+            # where chaos has to be injected
+            - name: TARGET_CONTAINER
+              value: 'nginx'
+
+            # Enter the amount of memory in megabytes to be consumed by the application pod
+            # default: 500 (Megabytes) 
+            - name: MEMORY_CONSUMPTION
+              value: ''
+
+            - name: TOTAL_CHAOS_DURATION
+              value: '60' # in seconds
+            

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -47,7 +47,7 @@ spec:
     # Enter the amount of memory in megabytes to be consumed by the application pod
     # default: 500 (Megabytes) 
     - name: MEMORY_CONSUMPTION
-      value: ''
+      value: '500'
 
     - name: TOTAL_CHAOS_DURATION
       value: '60' # in seconds

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -52,7 +52,7 @@ spec:
     - name: TOTAL_CHAOS_DURATION
       value: '60' # in seconds
 
-    # Period to wait before injection of chaos in sec
+    # Period to wait before and after injection of chaos in sec
     - name: RAMP_TIME
       value: ''
 

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -5,7 +5,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-memory-hog
-  version: 0.1.9
+  version: 0.1.0
 spec:
   definition:
     scope: Namespaced

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -1,0 +1,65 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Injects memory consumption on pods belonging to an app deployment
+kind: ChaosExperiment
+metadata:
+  name: pod-memory-hog
+  version: 0.1.9
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      - apiGroups:
+          - ""
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "events"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+    image: "litmuschaos/ansible-runner:latest"
+    args:
+    - -c
+    - ansible-playbook ./experiments/generic/pod_memory_hog/pod_memory_hog_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0
+    command:
+    - /bin/bash
+    env:
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: 'default'
+
+    # Provide name of target container
+    # where chaos has to be injected
+    - name: TARGET_CONTAINER
+      value: ''
+
+    # Enter the amount of memory in megabytes to be consumed by the application pod
+    # default: 500 (Megabytes) 
+    - name: MEMORY_CONSUMPTION
+      value: ''
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60' # in seconds
+
+    # Period to wait before injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    - name: LIB
+      value: 'litmus'
+
+    - name: LIB_IMAGE
+      value: 'litmuschaos/app-memory-stress:latest' 
+    labels:
+      name: pod-memory-hog

--- a/charts/generic/pod-memory-hog/pod-memory-hog.chartserviceversion.yaml
+++ b/charts/generic/pod-memory-hog/pod-memory-hog.chartserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: litmuchaos.io/v1alpha1
 kind: ChartServiceVersion
 metadata:
-  createdAt: 2019-01-07T10:28:08Z
+  createdAt: 2020-04-10T10:28:08Z
   name: pod-memory-hog
   version: 0.1.0
   annotations:
@@ -12,7 +12,7 @@ spec:
   displayName: pod-memory-hog
   categoryDescription: |
     Pod-Memory-Hog contains chaos to consume Memory resouces of specified containers in Kubernetes pods.  
-    - Causes high Memory resource consumption using dd command which maintains a temporary buffer in memory to write the chunk of data assigned in bs of the dd command.
+    - Consumes the memory specified by executing a dd command against special files /dev/zero(input) and /dev/null(output)
     - The application pod should be healthy once chaos is stopped. Expectation is that service-requests should be served despite chaos.
   keywords:
     - Kubernetes

--- a/charts/generic/pod-memory-hog/pod-memory-hog.chartserviceversion.yaml
+++ b/charts/generic/pod-memory-hog/pod-memory-hog.chartserviceversion.yaml
@@ -1,0 +1,42 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  createdAt: 2019-01-07T10:28:08Z
+  name: pod-memory-hog
+  version: 0.1.0
+  annotations:
+    categories: Kubernetes
+    vendor: CNCF
+    support: https://slack.kubernetes.io/
+spec:
+  displayName: pod-memory-hog
+  categoryDescription: |
+    Pod-Memory-Hog contains chaos to consume Memory resouces of specified containers in Kubernetes pods.  
+    - Causes high Memory resource consumption using dd command which maintains a temporary buffer in memory to write the chunk of data assigned in bs of the dd command.
+    - The application pod should be healthy once chaos is stopped. Expectation is that service-requests should be served despite chaos.
+  keywords:
+    - Kubernetes
+    - Memory
+  platforms:
+    - GKE
+    - Packet(Kubeadm)
+    - Minikube
+    - EKS
+  maturity: alpha
+  maintainers:
+    - name: Udit Gaurav
+      email: udit.gaurav@mayadata.io
+  minKubeVersion: 1.12.0
+  provider:
+    name: Mayadata
+  links:
+    - name: Source Code
+      url: https://github.com/litmuschaos/litmus/tree/master/experiments/generic/pod_memory_hog
+    - name: Documentation
+      url: https://docs.litmuschaos.io/docs/pod-memory-hog/
+    - name: Video
+      url: 
+  icon:
+    - base64data: ""
+      mediatype: ""
+  chaosexpcrdlink: https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-memory-hog/experiment.yaml 

--- a/charts/generic/pod-memory-hog/rbac.yaml
+++ b/charts/generic/pod-memory-hog/rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-memory-hog-sa
+  namespace: default
+  labels:
+    name: pod-memory-hog-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: pod-memory-hog-sa
+  namespace: default
+  labels:
+    name: pod-memory-hog-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch"]
+  resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: pod-memory-hog-sa
+  namespace: default
+  labels:
+    name: pod-memory-hog-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-memory-hog-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-memory-hog-sa
+  namespace: default


### PR DESCRIPTION
- Adding chaos chart for pod memory hog experiment. 
This include addition of:
  - engine
  - rabc
  - chart
  - csv file
  - experiment icon
issue - https://github.com/litmuschaos/litmus/issues/1414
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>