### PR TITLE
chore(engine): Add total chaos duration and chaos interval in container kill engine and typo fixes

### DIFF
--- a/charts/generic/container-kill/engine.yaml
+++ b/charts/generic/container-kill/engine.yaml
@@ -26,3 +26,11 @@ spec:
             # specify the name of the container to be killed
             - name: TARGET_CONTAINER
               value: 'nginx'
+
+            # provide the chaos interval
+            - name: CHAOS_INTERVAL
+              value: '10'
+
+            # provide the total chaos duration
+            - name: TOTAL_CHAOS_DURATION
+              value: '20'

--- a/charts/generic/pod-network-corruption/engine.yaml
+++ b/charts/generic/pod-network-corruption/engine.yaml
@@ -1,7 +1,7 @@
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name:  nginx-network-chaos
+  name: nginx-network-chaos
   namespace: default
 spec:
   # It can be delete/retain

--- a/charts/generic/pod-network-latency/engine.yaml
+++ b/charts/generic/pod-network-latency/engine.yaml
@@ -1,7 +1,7 @@
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name:  nginx-network-chaos
+  name: nginx-network-chaos
   namespace: default
 spec: 
   # It can be delete/retain


### PR DESCRIPTION
**Why do we need this pr?**
- This PR is for adding total chaos duration and chaos interval in container kill engine and some typo fixes. This will be helpful to manage these parameters form the engine itself. We have `TOTAL_CHAOS_DURATION` and `CHAOS_INTERVAL` in engine for other experiments but not for container-kill. This will be used in e2e and other places to change/modify according to our needs.

issue - https://github.com/litmuschaos/litmus/issues/1497
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>