### PR TITLE
bug(fix): Use stress-ng image in node cpu hog chaos experiment

### DIFF
--- a/charts/generic/node-cpu-hog/experiment.yaml
+++ b/charts/generic/node-cpu-hog/experiment.yaml
@@ -67,7 +67,7 @@ spec:
 
     # provide lib image
     - name: LIB_IMAGE
-      value: 'litmuschaos/cpu:latest' 
+      value: 'litmuschaos/stress-ng:latest' 
    
     labels:
       name: node-cpu-hog


### PR DESCRIPTION
- Use stress-ng image in node cpu hog chaos experiment. There is an older image in node cup hog experiment.yaml which is to be replaced with the new stress-ng image which contains the stress-ng and stress tool for doing resource chaos.
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>