### PR TITLE
update(rbac): Add more permission to run go-based experiments

### DIFF
--- a/charts/generic/pod-cpu-hog/rbac.yaml
+++ b/charts/generic/pod-cpu-hog/rbac.yaml
@@ -16,7 +16,7 @@ metadata:
     name: pod-cpu-hog-sa
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
-  resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["create","list","get","patch","update","delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/charts/generic/pod-memory-hog/rbac.yaml
+++ b/charts/generic/pod-memory-hog/rbac.yaml
@@ -16,7 +16,7 @@ metadata:
     name: pod-memory-hog-sa
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
-  resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["create","list","get","patch","update","delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

- Adding more and minimal permission to run go based pod cpu hog and pod memory hog experiment.
