### PR TITLE
(chore) add workflows to chaos-charts repo

### DIFF
--- a/workflows/node-cpu-hog/workflow.yaml
+++ b/workflows/node-cpu-hog/workflow.yaml
@@ -1,0 +1,54 @@
+## Refer to https://github.com/litmuschaos/chaos-workflows.git to setup the argo infrastructure
+## Uses admin mode of litmus execution
+
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: node-cpu-cron-wf
+spec:
+  schedule: "5/10 * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  workflowSpec:
+    entrypoint: argowf-chaos
+    serviceAccountName: argo-chaos
+    templates:
+    - name: argowf-chaos
+      steps:
+        - - name: run-node-cpu-hog
+            template: run-node-cpu-hog
+    - name: run-node-cpu-hog
+      inputs:
+        artifacts:
+        - name: run-node-cpu-hog
+          path: /tmp/chaosengine-1.yaml
+          raw:
+            data: |
+              apiVersion: litmuschaos.io/v1alpha1
+              kind: ChaosEngine
+              metadata:
+                name: node-cpu-hog
+                namespace: litmus
+              spec:
+                appinfo:
+                  appns: kube-system
+                  applabel: "k8s-app=kube-proxy"
+                  appkind: daemonset
+                jobCleanUpPolicy: retain
+                monitoring: true
+                annotationCheck: 'false'
+                engineState: 'active'
+                chaosServiceAccount: litmus-admin
+                experiments:
+                  - name: node-cpu-hog
+                    spec:
+                      components:
+                        env:
+                          - name: TOTAL_CHAOS_DURATION
+                            value: "60"
+                          - name: NODE_CPU_CORE
+                            value: ""
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args: ['kubectl apply -f /tmp/chaosengine-1.yaml -n litmus']

--- a/workflows/node-memory-hog/workflow.yaml
+++ b/workflows/node-memory-hog/workflow.yaml
@@ -1,0 +1,55 @@
+## Refer to https://github.com/litmuschaos/chaos-workflows.git to setup the argo infrastructure
+## Uses admin mode of litmus execution
+
+
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: node-memory-cron-wf
+spec:
+  schedule: "0/10 * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  workflowSpec:
+    entrypoint: argowf-chaos
+    serviceAccountName: argo-chaos
+    templates:
+    - name: argowf-chaos
+      steps:
+        - - name: run-node-memory-hog
+            template: run-node-memory-hog
+    - name: run-node-memory-hog
+      inputs:
+        artifacts:
+        - name: run-node-memory-hog
+          path: /tmp/chaosengine-2.yaml
+          raw:
+            data: |
+              apiVersion: litmuschaos.io/v1alpha1
+              kind: ChaosEngine
+              metadata:
+                name: node-memory-hog
+                namespace: litmus
+              spec:
+                appinfo:
+                  appns: kube-system
+                  applabel: "k8s-app=kube-proxy"
+                  appkind: daemonset
+                jobCleanUpPolicy: retain
+                monitoring: true
+                annotationCheck: 'false'
+                engineState: 'active'
+                chaosServiceAccount: litmus-admin
+                experiments:
+                  - name: node-memory-hog
+                    spec:
+                      components:
+                        env:
+                          - name: TOTAL_CHAOS_DURATION
+                            value: "60"
+                          - name: MEMORY_PERCENTAGE
+                            value: "90"
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args: ['kubectl apply -f /tmp/chaosengine-2.yaml -n litmus']


### PR DESCRIPTION
- Adds the first set of pre-defined workflows to chaos-charts
- Fixes: https://github.com/litmuschaos/litmus/issues/1790

#### TODO
- chartServiceVersion files for workflows for metadata representation/render on portal
- Workflow categorization

Signed-off-by: ksatchit <karthik.s@mayadata.io>