### PR TITLE
chore(lib): Add pumba lib image for pod level resource chaos

### DIFF
--- a/charts/generic/kubelet-service-kill/experiment.yaml
+++ b/charts/generic/kubelet-service-kill/experiment.yaml
@@ -56,6 +56,10 @@ spec:
     - name: LIB
       value: 'litmus'
 
+    # provide lib image
+    - name: LIB_IMAGE
+      value: 'litmuschaos/go-runner:latest' 
+            
     # provide node name
     - name: APP_NODE
       value: ''

--- a/charts/generic/pod-cpu-hog/experiment.yaml
+++ b/charts/generic/pod-cpu-hog/experiment.yaml
@@ -38,7 +38,7 @@ spec:
     - /bin/bash
     env:
     - name: TOTAL_CHAOS_DURATION
-      value: '30'
+      value: '60'
     
     - name: CHAOS_INTERVAL
       value: '10'
@@ -55,8 +55,14 @@ spec:
     - name: RAMP_TIME
       value: ''
 
+    ## env var that describes the library used to execute the chaos
+    ## default: litmus. Supported values: litmus, pumba    
     - name: LIB
       value: 'litmus'
+
+    ## It is used in pumba lib only    
+    - name: LIB_IMAGE
+      value: 'gaiaadm/pumba'  
 
     - name: TARGET_POD
       value: ''

--- a/charts/generic/pod-cpu-hog/rbac.yaml
+++ b/charts/generic/pod-cpu-hog/rbac.yaml
@@ -17,7 +17,7 @@ metadata:
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
-  verbs: ["create","list","get","patch","update","delete"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -38,7 +38,7 @@ spec:
     - /bin/bash
     env:
       - name: TOTAL_CHAOS_DURATION
-        value: '30'
+        value: '60'
 
       - name: CHAOS_INTERVAL
         value: '10'
@@ -56,9 +56,13 @@ spec:
         value: ''     
 
       ## env var that describes the library used to execute the chaos
-      ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+      ## default: litmus. Supported values: litmus, pumba
       - name: LIB
         value: 'litmus'
+
+      ## It is used in pumba lib only    
+      - name: LIB_IMAGE
+        value: 'gaiaadm/pumba'
 
       - name: TARGET_POD
         value: ''

--- a/charts/generic/pod-memory-hog/rbac.yaml
+++ b/charts/generic/pod-memory-hog/rbac.yaml
@@ -17,7 +17,7 @@ metadata:
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
-  verbs: ["create","list","get","patch","update","delete"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

#### Issues:
- fixes: https://github.com/litmuschaos/litmus/issues/2017

#### This PR is for:
- Adding pumba lib image for pod level resource chaos charts