### PR TITLE
Adding kube-proxy-all chaos workflow

### DIFF
--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -1,0 +1,245 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: argowf-chaos-kube-proxy-all-
+  namespace: litmus
+spec:
+  entrypoint: argowf-chaos
+  serviceAccountName: argo-chaos
+  arguments:
+    parameters:
+      - name: adminModeNamespace
+        value: litmus
+
+  templates:
+    - name: argowf-chaos
+      steps:
+        - - name: install-chaos-experiments
+            template: install-chaos-experiments
+        - - name: node-cpu-hog
+            template: node-cpu-hog
+          - name: pod-memory-hog
+            template: pod-memory-hog
+        - - name: pod-cpu-hog
+            template: pod-cpu-hog
+          - name: node-memory-hog
+            template: node-memory-hog
+        - - name: pod-delete
+            template: pod-delete
+        - - name: revert-kube-proxy-chaos
+            template: revert-kube-proxy-chaos
+
+    - name: install-chaos-experiments
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.8.0?file=charts/generic/experiments.yaml -n
+            {{workflow.parameters.adminModeNamespace}} | sleep 30"
+
+    - name: node-cpu-hog
+      inputs:
+        artifacts:
+          - name: node-cpu-hog
+            path: /tmp/chaosengine-node-cpu-hog.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: kube-proxy-node-cpu-hog
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: kube-system
+                    applabel: "k8s-app=kube-proxy"
+                    appkind: daemonset
+                  jobCleanUpPolicy: retain
+                  monitoring: false
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  experiments:
+                    - name: node-cpu-hog
+                      spec:
+                        components:
+                          env:
+                            - name: NODE_CPU_CORE
+                              value: '1'
+
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60' # in seconds
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f /tmp/chaosengine-node-cpu-hog.yaml -n
+            {{workflow.parameters.adminModeNamespace}} | sleep 90"
+
+    - name: pod-memory-hog
+      inputs:
+        artifacts:
+          - name: pod-memory-hog
+            path: /tmp/chaosengine-pod-memory-hog.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: kube-proxy-pod-memory-hog-chaos
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: kube-system
+                    applabel: "k8s-app=kube-proxy"
+                    appkind: daemonset
+                  jobCleanUpPolicy: retain
+                  monitoring: false
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  experiments:
+                    - name: pod-memory-hog
+                      spec:
+                        components:
+                          experimentImage: "litmuschaos/go-runner:ci"
+                          env:
+                            - name: TARGET_CONTAINER
+                              value: 'kube-proxy'
+                            - name: MEMORY_CONSUMPTION
+                              value: '500'
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60' # in seconds
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f /tmp/chaosengine-pod-memory-hog.yaml -n
+            {{workflow.parameters.adminModeNamespace}} | sleep 90"
+
+    - name: pod-cpu-hog
+      inputs:
+        artifacts:
+          - name: pod-cpu-hog
+            path: /tmp/chaosengine-pod-cpu-hog.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: kube-proxy-pod-cpu-hog-chaos
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: kube-system
+                    applabel: "k8s-app=kube-proxy"
+                    appkind: daemonset
+                  jobCleanUpPolicy: retain
+                  monitoring: false
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  experiments:
+                    - name: pod-cpu-hog
+                      spec:
+                        components:
+                          experimentImage: "litmuschaos/go-runner:ci"
+                          env:
+                            - name: TARGET_CONTAINER
+                              value: 'kube-proxy'
+                            - name: CPU_CORES
+                              value: '1'
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60' # in seconds
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f /tmp/chaosengine-pod-cpu-hog.yaml -n
+            {{workflow.parameters.adminModeNamespace}} | sleep 90"
+
+    - name: node-memory-hog
+      inputs:
+        artifacts:
+          - name: node-memory-hog
+            path: /tmp/chaosengine-node-memory-hog.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: kube-proxy-node-memory-hog-chaos
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: kube-system
+                    applabel: "k8s-app=kube-proxy"
+                    appkind: daemonset
+                  jobCleanUpPolicy: retain
+                  monitoring: false
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  experiments:
+                    - name: node-memory-hog
+                      spec:
+                        components:
+                          env:
+                            - name: MEMORY_PERCENTAGE
+                              value: '50'
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60' # in seconds
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f /tmp/chaosengine-node-memory-hog.yaml -n
+            {{workflow.parameters.adminModeNamespace}} | sleep 90"
+
+    - name: pod-delete
+      inputs:
+        artifacts:
+          - name: pod-delete
+            path: /tmp/chaosengine-pod-delete.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: kube-proxy-pod-delete-chaos
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: kube-system
+                    applabel: "k8s-app=kube-proxy"
+                    appkind: daemonset
+                  jobCleanUpPolicy: retain
+                  monitoring: false
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  experiments:
+                    - name: pod-delete
+                      spec:
+                        components:
+                          env:
+                            - name: TOTAL_CHAOS_DURATION
+                              value: "60"
+                            - name: CHAOS_INTERVAL
+                              value: "10"
+                            - name: FORCE
+                              value: "false"
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f /tmp/chaosengine-pod-delete.yaml -n
+            {{workflow.parameters.adminModeNamespace}} | sleep 90"
+
+    - name: revert-all-chaos
+      container:
+        image: lachlanevenson/k8s-kubectl
+        command: [sh, -c]
+        args:
+          - "sleep 100 | kubectl delete chaosengines --all -n
+            {{workflow.parameters.adminModeNamespace}}"


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishan.gupta@mayadata.io>

Adding kube-proxy-all argo workflow having 5 chaos experiments to target kube-proxy in kube-system namespace.

- Node CPU hog.
- Node memory hog.
- Pod CPU hog.
- Pod memory hog.
- Pod delete.