### PR TITLE
chore(auto_release): Add auto release in chaos-charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# The CI will create a release branch 
+# with CR updated with release tag
+
+# The workflow will trigger when a release tag is created
+name: ChaosCharts-Release
+on:
+  push:
+    tags:
+    - '*'
+    
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # It will checkout to the relase branch provided in the secret
+    - name: Checkout to release branch
+      run: |
+        git config --local user.email "litmuschaos@gmail.com"
+        git config --local user.name "LitmusChaos"
+        git checkout -b ${{ secrets.RELEASE_BRANCH }}
+
+    # It will update the image tag as provided in the secret
+    - name: Update the chaos-charts version
+      run: |
+        find charts -type f -exec sed -i 's/\:latest/\:${{ secrets.RELEASE_VERSION }}/g' {} \;
+
+    - name: Commit files
+      run: |
+        git add .          
+        git commit -s -m "New Release ${{ secrets.RELEASE_VERSION }}"
+  
+    # It will push the changes in realse branch
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ secrets.RELEASE_BRANCH }}


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

This PR is for automating the release process of chaos-charts which includes the following changes:

1. Addition of release branch
2. pushing the code to the release branch with updated image tags.

The action will trigger whenever a new tag is created.

Please refer the tested repo here: (https://github.com/uditgaurav/test-chaos-charts/runs/1192793107)