### PR TITLE
(enhancement)charts: add standard kubernetes labels to experiments

### DIFF
--- a/charts/cassandra/cassandra-pod-delete/experiment.yaml
+++ b/charts/cassandra/cassandra-pod-delete/experiment.yaml
@@ -108,3 +108,4 @@ spec:
 
     labels:
       name: cassandra-pod-delete
+      app.kubernetes.io/part-of: litmus

--- a/charts/cassandra/cassandra-pod-delete/rbac.yaml
+++ b/charts/cassandra/cassandra-pod-delete/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: cassandra-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: cassandra-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","statefulsets","services","pods/log","pods/exec","events","jobs","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: cassandra-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/coredns/coredns-pod-delete/experiment.yaml
+++ b/charts/coredns/coredns-pod-delete/experiment.yaml
@@ -62,3 +62,4 @@ spec:
 
     labels:
       name: coredns-pod-delete
+      app.kubernetes.io/part-of: litmus

--- a/charts/coredns/coredns-pod-delete/rbac.yaml
+++ b/charts/coredns/coredns-pod-delete/rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     name: coredns-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,6 +13,7 @@ metadata:
   name: coredns-pod-delete-sa
   labels:
     name: coredns-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["services", "pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -23,6 +25,7 @@ metadata:
   name: coredns-pod-delete-sa
   labels:
     name: coredns-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/container-kill/ansible/experiment.yaml
+++ b/charts/generic/container-kill/ansible/experiment.yaml
@@ -73,3 +73,4 @@ spec:
 
     labels:
       name: container-kill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/container-kill/ansible/rbac.yaml
+++ b/charts/generic/container-kill/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: container-kill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: container-kill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/exec","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: container-kill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/container-kill/experiment.yaml
+++ b/charts/generic/container-kill/experiment.yaml
@@ -89,3 +89,4 @@ spec:
     
     labels:
       name: container-kill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/container-kill/rbac.yaml
+++ b/charts/generic/container-kill/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: container-kill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: container-kill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/exec","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: container-kill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/disk-fill/ansible/experiment.yaml
+++ b/charts/generic/disk-fill/ansible/experiment.yaml
@@ -67,3 +67,4 @@ spec:
 
     labels:
       name: disk-fill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/disk-fill/ansible/rbac.yaml
+++ b/charts/generic/disk-fill/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: disk-fill-sa
   labels:
     name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch"]
   resources: ["pods","jobs","pods/exec","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -24,6 +26,7 @@ metadata:
   name: disk-fill-sa
   labels:
     name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/disk-fill/experiment.yaml
+++ b/charts/generic/disk-fill/experiment.yaml
@@ -80,3 +80,4 @@ spec:
 
     labels:
       name: disk-fill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/disk-fill/rbac.yaml
+++ b/charts/generic/disk-fill/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: disk-fill-sa
   labels:
     name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch"]
   resources: ["pods","jobs","pods/exec","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -24,6 +26,7 @@ metadata:
   name: disk-fill-sa
   labels:
     name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/disk-loss/experiment.yaml
+++ b/charts/generic/disk-loss/experiment.yaml
@@ -76,6 +76,7 @@ spec:
           
     labels:
       name: disk-loss
+      app.kubernetes.io/part-of: litmus
     secrets:
     - name: cloud-secret
       mountPath: /tmp/

--- a/charts/generic/disk-loss/rbac.yaml
+++ b/charts/generic/disk-loss/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: disk-loss-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: disk-loss-sa
   labels:
     name: disk-loss-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","secrets","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -24,6 +26,7 @@ metadata:
   name: disk-loss-sa
   labels:
     name: disk-loss-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/docker-service-kill/experiment.yaml
+++ b/charts/generic/docker-service-kill/experiment.yaml
@@ -58,4 +58,5 @@ spec:
       value: 'litmus'
     labels:
       name: docker-service-kill
+      app.kubernetes.io/part-of: litmus
 

--- a/charts/generic/docker-service-kill/rbac.yaml
+++ b/charts/generic/docker-service-kill/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: docker-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: docker-service-kill-sa
   labels:
     name: docker-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: docker-service-kill-sa
   labels:
     name: docker-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/k8-pod-delete/experiment.yaml
+++ b/charts/generic/k8-pod-delete/experiment.yaml
@@ -73,3 +73,4 @@ spec:
 
     labels:
       name: k8-pod-delete
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/k8-pod-delete/rbac.yaml
+++ b/charts/generic/k8-pod-delete/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: k8-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: k8-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
@@ -29,6 +31,7 @@ metadata:
   namespace: default
   labels:
     name: k8-pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/k8-service-kill/experiment.yaml
+++ b/charts/generic/k8-service-kill/experiment.yaml
@@ -73,3 +73,4 @@ spec:
 
     labels:
       name: k8-service-kill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/k8-service-kill/rbac.yaml
+++ b/charts/generic/k8-service-kill/rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8-service-kill-sa
   labels:
     name: k8-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -11,6 +12,7 @@ metadata:
   name: k8-service-kill-sa
   labels:
     name: k8-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","batch","extensions","litmuschaos.io","openebs.io","storage.k8s.io"]
   resources: ["chaosengines","chaosexperiments","chaosresults","configmaps","cstorpools","cstorvolumereplicas","events","jobs","persistentvolumeclaims","persistentvolumes","pods","pods/exec","pods/log","secrets","storageclasses","chaosengines","chaosexperiments","chaosresults","configmaps","cstorpools","cstorvolumereplicas","daemonsets","deployments","events","jobs","persistentvolumeclaims","persistentvolumes","pods","pods/eviction","pods/exec","pods/log","replicasets","secrets","services","statefulsets","storageclasses"]
@@ -25,6 +27,7 @@ metadata:
   name: k8-service-kill-sa
   labels:
     name: k8-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/kubelet-service-kill/ansible/experiment.yaml
+++ b/charts/generic/kubelet-service-kill/ansible/experiment.yaml
@@ -58,3 +58,4 @@ spec:
       value: 'litmus'
     labels:
       name: kubelet-service-kill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/kubelet-service-kill/ansible/rbac.yaml
+++ b/charts/generic/kubelet-service-kill/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: kubelet-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: kubelet-service-kill-sa
   labels:
     name: kubelet-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: kubelet-service-kill-sa
   labels:
     name: kubelet-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/kubelet-service-kill/experiment.yaml
+++ b/charts/generic/kubelet-service-kill/experiment.yaml
@@ -65,3 +65,4 @@ spec:
 
     labels:
       name: kubelet-service-kill
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/kubelet-service-kill/rbac.yaml
+++ b/charts/generic/kubelet-service-kill/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: kubelet-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: kubelet-service-kill-sa
   labels:
     name: kubelet-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: kubelet-service-kill-sa
   labels:
     name: kubelet-service-kill-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-cpu-hog/ansible/experiment.yaml
+++ b/charts/generic/node-cpu-hog/ansible/experiment.yaml
@@ -71,3 +71,4 @@ spec:
    
     labels:
       name: node-cpu-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-cpu-hog/ansible/rbac.yaml
+++ b/charts/generic/node-cpu-hog/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-cpu-hog-sa
   labels:
     name: node-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","events","chaosengines","pods/log","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-cpu-hog-sa
   labels:
     name: node-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-cpu-hog/experiment.yaml
+++ b/charts/generic/node-cpu-hog/experiment.yaml
@@ -72,3 +72,4 @@ spec:
    
     labels:
       name: node-cpu-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-cpu-hog/rbac.yaml
+++ b/charts/generic/node-cpu-hog/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-cpu-hog-sa
   labels:
     name: node-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","events","chaosengines","pods/log","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-cpu-hog-sa
   labels:
     name: node-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-drain/ansible/experiment.yaml
+++ b/charts/generic/node-drain/ansible/experiment.yaml
@@ -74,3 +74,4 @@ spec:
 
     labels:
       name: node-drain
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-drain/ansible/rbac.yaml
+++ b/charts/generic/node-drain/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-drain-sa
   labels:
     name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","extensions"]
   resources: ["pods","jobs","events","chaosengines","pods/log","daemonsets","pods/eviction","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-drain-sa
   labels:
     name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-drain/experiment.yaml
+++ b/charts/generic/node-drain/experiment.yaml
@@ -67,3 +67,4 @@ spec:
 
     labels:
       name: node-drain
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-drain/rbac.yaml
+++ b/charts/generic/node-drain/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-drain-sa
   labels:
     name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","extensions","apps"]
   resources: ["pods","jobs","events","chaosengines","pods/log","daemonsets","pods/eviction","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-drain-sa
   labels:
     name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-io-stress/experiment.yaml
+++ b/charts/generic/node-io-stress/experiment.yaml
@@ -81,3 +81,4 @@ spec:
       
     labels:
       name: node-io-stress
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-io-stress/rbac.yaml
+++ b/charts/generic/node-io-stress/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-io-stress-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-io-stress-sa
   labels:
     name: node-io-stress-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-io-stress-sa
   labels:
     name: node-io-stress-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-memory-hog/ansible/experiment.yaml
+++ b/charts/generic/node-memory-hog/ansible/experiment.yaml
@@ -71,3 +71,4 @@ spec:
       
     labels:
       name: node-memory-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-memory-hog/ansible/rbac.yaml
+++ b/charts/generic/node-memory-hog/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-memory-hog-sa
   labels:
     name: node-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-memory-hog-sa
   labels:
     name: node-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-memory-hog/experiment.yaml
+++ b/charts/generic/node-memory-hog/experiment.yaml
@@ -72,3 +72,4 @@ spec:
       
     labels:
       name: node-memory-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-memory-hog/rbac.yaml
+++ b/charts/generic/node-memory-hog/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-memory-hog-sa
   labels:
     name: node-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-memory-hog-sa
   labels:
     name: node-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/node-taint/experiment.yaml
+++ b/charts/generic/node-taint/experiment.yaml
@@ -72,3 +72,4 @@ spec:
 
     labels:
       name: node-taint
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/node-taint/rbac.yaml
+++ b/charts/generic/node-taint/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: node-taint-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: node-taint-sa
   labels:
     name: node-taint-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","extensions"]
   resources: ["pods","jobs","events","chaosengines","pods/log","daemonsets","pods/eviction","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: node-taint-sa
   labels:
     name: node-taint-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/pod-autoscaler/experiment.yaml
+++ b/charts/generic/pod-autoscaler/experiment.yaml
@@ -64,3 +64,4 @@ spec:
   
     labels:
       name: pod-autoscaler
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-autoscaler/rbac.yaml
+++ b/charts/generic/pod-autoscaler/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-autoscaler-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: pod-autoscaler-sa
   labels:
     name: pod-autoscaler-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","jobs","events","chaosengines","pods/log","chaosexperiments","chaosresults"]
@@ -27,6 +29,7 @@ metadata:
   name: pod-autoscaler-sa
   labels:
     name: pod-autoscaler-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/generic/pod-cpu-hog/ansible/experiment.yaml
+++ b/charts/generic/pod-cpu-hog/ansible/experiment.yaml
@@ -59,3 +59,4 @@ spec:
       value: 'litmuschaos/app-cpu-stress:latest' 
     labels:
       name: pod-cpu-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-cpu-hog/ansible/rbac.yaml
+++ b/charts/generic/pod-cpu-hog/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-cpu-hog/experiment.yaml
+++ b/charts/generic/pod-cpu-hog/experiment.yaml
@@ -75,3 +75,4 @@ spec:
       
     labels:
       name: pod-cpu-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-cpu-hog/rbac.yaml
+++ b/charts/generic/pod-cpu-hog/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-cpu-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-delete/ansible/experiment.yaml
+++ b/charts/generic/pod-delete/ansible/experiment.yaml
@@ -74,3 +74,4 @@ spec:
       value: 'litmus'    
     labels:
       name: pod-delete
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-delete/ansible/rbac.yaml
+++ b/charts/generic/pod-delete/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","pods/log","events","jobs","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-delete/experiment.yaml
+++ b/charts/generic/pod-delete/experiment.yaml
@@ -71,3 +71,4 @@ spec:
       
     labels:
       name: pod-delete
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-delete/rbac.yaml
+++ b/charts/generic/pod-delete/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","pods/log","events","jobs","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-io-stress/experiment.yaml
+++ b/charts/generic/pod-io-stress/experiment.yaml
@@ -79,3 +79,4 @@ spec:
 
     labels:
       name: pod-io-stress
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-io-stress/rbac.yaml
+++ b/charts/generic/pod-io-stress/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-io-stress-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-io-stress-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-io-stress-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-memory-hog/ansible/experiment.yaml
+++ b/charts/generic/pod-memory-hog/ansible/experiment.yaml
@@ -63,3 +63,4 @@ spec:
       value: 'litmuschaos/app-memory-stress:latest' 
     labels:
       name: pod-memory-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-memory-hog/ansible/rbac.yaml
+++ b/charts/generic/pod-memory-hog/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -75,3 +75,4 @@ spec:
 
     labels:
       name: pod-memory-hog
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-memory-hog/rbac.yaml
+++ b/charts/generic/pod-memory-hog/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","pods/exec","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-corruption/ansible/experiment.yaml
+++ b/charts/generic/pod-network-corruption/ansible/experiment.yaml
@@ -66,3 +66,4 @@ spec:
       value: 'pumba'
     labels:
       name: pod-network-corruption
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-corruption/ansible/rbac.yaml
+++ b/charts/generic/pod-network-corruption/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-corruption/experiment.yaml
+++ b/charts/generic/pod-network-corruption/experiment.yaml
@@ -99,3 +99,4 @@ spec:
       
     labels:
       name: pod-network-corruption
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-corruption/rbac.yaml
+++ b/charts/generic/pod-network-corruption/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-duplication/experiment.yaml
+++ b/charts/generic/pod-network-duplication/experiment.yaml
@@ -95,3 +95,4 @@ spec:
 
     labels:
       name: pod-network-duplication
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-duplication/rbac.yaml
+++ b/charts/generic/pod-network-duplication/rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-duplication-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -13,6 +14,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-duplication-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -25,6 +27,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-duplication-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-latency/ansible/experiment.yaml
+++ b/charts/generic/pod-network-latency/ansible/experiment.yaml
@@ -66,3 +66,4 @@ spec:
       value: 'pumba'
     labels:
       name: pod-network-latency
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-latency/ansible/rbac.yaml
+++ b/charts/generic/pod-network-latency/ansible/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-latency/experiment.yaml
+++ b/charts/generic/pod-network-latency/experiment.yaml
@@ -99,3 +99,4 @@ spec:
 
     labels:
       name: pod-network-latency
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-latency/rbac.yaml
+++ b/charts/generic/pod-network-latency/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","pods/log","events","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-loss/ansible/experiment.yaml
+++ b/charts/generic/pod-network-loss/ansible/experiment.yaml
@@ -66,3 +66,4 @@ spec:
       value: 'pumba'
     labels:
       name: pod-network-loss
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-loss/ansible/rbac.yaml
+++ b/charts/generic/pod-network-loss/ansible/rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -13,6 +14,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -25,6 +27,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/generic/pod-network-loss/experiment.yaml
+++ b/charts/generic/pod-network-loss/experiment.yaml
@@ -99,3 +99,4 @@ spec:
       
     labels:
       name: pod-network-loss
+      app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-loss/rbac.yaml
+++ b/charts/generic/pod-network-loss/rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -13,6 +14,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch"]
   resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
@@ -25,6 +27,7 @@ metadata:
   namespace: default
   labels:
     name: pod-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kafka/kafka-broker-disk-failure/experiment.yaml
+++ b/charts/kafka/kafka-broker-disk-failure/experiment.yaml
@@ -104,6 +104,7 @@ spec:
       value: ''
     labels:
       name: kafka-broker-disk-failure
+      app.kubernetes.io/part-of: litmus
     secrets:
     - name: kafka-broker-disk-failure
       mountPath: /tmp/

--- a/charts/kafka/kafka-broker-disk-failure/rbac.yaml
+++ b/charts/kafka/kafka-broker-disk-failure/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: kafka-broker-disk-failure-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: kafka-broker-disk-failure-sa
   labels:
     name: kafka-broker-disk-failure-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","jobs","pods/log","events","pods/exec","statefulsets","secrets","chaosengines","chaosexperiments","chaosresults"]
@@ -24,6 +26,7 @@ metadata:
   name: kafka-broker-disk-failure-sa
   labels:
     name: kafka-broker-disk-failure-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kafka/kafka-broker-pod-failure/experiment.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/experiment.yaml
@@ -124,3 +124,4 @@ spec:
  
     labels:
       name: kafka-broker-pod-failure
+      app.kubernetes.io/part-of: litmus

--- a/charts/kafka/kafka-broker-pod-failure/rbac.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
   labels:
     name: kafka-broker-pod-failure-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,6 +13,7 @@ metadata:
   name: kafka-broker-pod-failure-sa
   labels:
     name: kafka-broker-pod-failure-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","pods/log","events","jobs","pods/exec","statefulsets","configmaps","chaosengines","chaosexperiments","chaosresults"]
@@ -26,6 +28,7 @@ metadata:
   name: kafka-broker-pod-failure-sa
   labels:
     name: kafka-broker-pod-failure-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kube-aws/k8-aws-ec2-terminate/experiment.yaml
+++ b/charts/kube-aws/k8-aws-ec2-terminate/experiment.yaml
@@ -101,4 +101,5 @@ spec:
 
     labels:
       name: k8-aws-ec2-terminate
+      app.kubernetes.io/part-of: litmus
 

--- a/charts/kube-aws/k8-aws-ec2-terminate/rbac.yaml
+++ b/charts/kube-aws/k8-aws-ec2-terminate/rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8-aws-ec2-terminate-sa
   labels:
     name: k8-aws-ec2-terminate-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -11,6 +12,7 @@ metadata:
   name: k8-aws-ec2-terminate-sa
   labels:
     name: k8-aws-ec2-terminate-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","batch","extensions","litmuschaos.io","openebs.io","storage.k8s.io"]
   resources: ["chaosengines","chaosexperiments","chaosresults","configmaps","cstorpools","cstorvolumereplicas","events","jobs","persistentvolumeclaims","persistentvolumes","pods","pods/exec","pods/log","secrets","storageclasses","chaosengines","chaosexperiments","chaosresults","configmaps","cstorpools","cstorvolumereplicas","daemonsets","deployments","events","jobs","persistentvolumeclaims","persistentvolumes","pods","pods/eviction","pods/exec","pods/log","replicasets","secrets","services","statefulsets","storageclasses"]
@@ -25,6 +27,7 @@ metadata:
   name: k8-aws-ec2-terminate-sa
   labels:
     name: k8-aws-ec2-terminate-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-control-plane-chaos/experiment.yaml
+++ b/charts/openebs/openebs-control-plane-chaos/experiment.yaml
@@ -70,3 +70,4 @@ spec:
 
     labels:
       name: openebs-control-plane-chaos
+      app.kubernetes.io/part-of: litmus

--- a/charts/openebs/openebs-control-plane-chaos/rbac.yaml
+++ b/charts/openebs/openebs-control-plane-chaos/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openebs
   labels:
     name: control-plane-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,6 +15,7 @@ metadata:
   namespace: openebs
   labels:
     name: control-plane-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","pods/log","events","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
@@ -29,6 +31,7 @@ metadata:
   namespace: openebs
   labels:
     name: control-plane-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/openebs/openebs-nfs-provisioner-kill/experiment.yaml
+++ b/charts/openebs/openebs-nfs-provisioner-kill/experiment.yaml
@@ -88,6 +88,7 @@ spec:
 
     labels:
       name: openebs-nfs-provisioner-kill
+      app.kubernetes.io/part-of: litmus
     configmaps:
       - name: openebs-nfs-provisioner-kill
         mountPath: /mnt/

--- a/charts/openebs/openebs-nfs-provisioner-kill/rbac.yaml
+++ b/charts/openebs/openebs-nfs-provisioner-kill/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: nfs-chaos-sa
+    app.kubernetes.io/part-of: litmus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +14,7 @@ metadata:
   name: nfs-chaos-sa
   labels:
     name: nfs-chaos-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io"]
   resources: ["pods","pods/exec","pods/log", "deployments","events","jobs","configmaps","services","persistentvolumeclaims","storageclasses","persistentvolumes","chaosexperiments","chaosresults","chaosengines"]
@@ -24,6 +26,7 @@ metadata:
   name: nfs-chaos-sa
   labels:
     name: nfs-chaos-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-pool-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-container-failure/experiment.yaml
@@ -85,6 +85,7 @@ spec:
 
     labels:
       name: openebs-pool-container-failure
+      app.kubernetes.io/part-of: litmus
     #configmaps:
     #- name: openebs-pool-container-failure
     #  mountPath: /mnt

--- a/charts/openebs/openebs-pool-container-failure/rbac.yaml
+++ b/charts/openebs/openebs-pool-container-failure/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pool-container-failure-sa
+    app.kubernetes.io/part-of: litmus
 ---
 # Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ metadata:
   name: pool-container-failure-sa
   labels:
     name: pool-container-failure-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io","openebs.io"]
   resources: ["pods","jobs","events","pods/log","replicasets","pods/exec","configmaps","secrets","persistentvolumeclaims","cstorvolumereplicas","chaosexperiments","chaosresults","chaosengines"]
@@ -25,6 +27,7 @@ metadata:
   name: pool-container-failure-sa
   labels:
     name: pool-container-failure-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-pool-disk-loss/experiment.yaml
+++ b/charts/openebs/openebs-pool-disk-loss/experiment.yaml
@@ -94,6 +94,7 @@ spec:
         
     labels:
       name: openebs-pool-disk-loss
+      app.kubernetes.io/part-of: litmus
 
     configmaps:
     - name: openebs-pool-disk-loss

--- a/charts/openebs/openebs-pool-disk-loss/rbac.yaml
+++ b/charts/openebs/openebs-pool-disk-loss/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: pool-disk-loss-sa
+    app.kubernetes.io/part-of: litmus
 ---
 # Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ metadata:
   name: pool-disk-loss-sa
   labels:
     name: pool-disk-loss-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io","openebs.io"]
   resources: ["pods", "pods/log", "jobs", "events", "pods/exec", "cstorpools", "configmaps", "secrets", "storageclasses", "persistentvolumes", "persistentvolumeclaims", "cstorvolumereplicas", "chaosexperiments", "chaosresults", "chaosengines"]
@@ -25,6 +27,7 @@ metadata:
   name: pool-disk-loss-sa
   labels:
     name: pool-disk-loss-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-pool-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-pool-network-delay/experiment.yaml
@@ -84,3 +84,4 @@ spec:
 
     labels:
       name: openebs-pool-network-delay
+      app.kubernetes.io/part-of: litmus 

--- a/charts/openebs/openebs-pool-network-loss/experiment.yaml
+++ b/charts/openebs/openebs-pool-network-loss/experiment.yaml
@@ -83,3 +83,4 @@ spec:
 
     labels:
       name: openebs-pool-network-loss
+      app.kubernetes.io/part-of: litmus

--- a/charts/openebs/openebs-pool-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-pool-pod-failure/experiment.yaml
@@ -84,6 +84,7 @@ spec:
 
     labels:
       name: openebs-pool-pod-failure
+      app.kubernetes.io/part-of: litmus
     #configmaps:
     #- name: openebs-pool-pod-failure
     #  mountPath: /mnt

--- a/charts/openebs/openebs-target-container-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-container-failure/experiment.yaml
@@ -101,6 +101,7 @@ spec:
       
     labels:
       name: openebs-target-container-failure
+      app.kubernetes.io/part-of: litmus
     #configmaps:
     #- name: openebs-target-container-failure
     #  mountPath: /mnt

--- a/charts/openebs/openebs-target-container-failure/rbac.yaml
+++ b/charts/openebs/openebs-target-container-failure/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: target-container-failure-sa
+    app.kubernetes.io/part-of: litmus
 ---
 # Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ metadata:
   name: target-container-failure-sa
   labels:
     name: target-container-failure-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps","storage.k8s.io"]
   resources: ["pods","jobs","pods/log","pods/exec","events","configmaps","secrets","persistentvolumeclaims","storageclasses","persistentvolumes","chaosengines","chaosexperiments","chaosresults"]
@@ -25,6 +27,7 @@ metadata:
   name: target-container-failure-sa
   labels:
     name: target-container-failure-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-target-network-delay/experiment.yaml
+++ b/charts/openebs/openebs-target-network-delay/experiment.yaml
@@ -82,6 +82,7 @@ spec:
 
     labels:
       name: openebs-target-network-delay
+      app.kubernetes.io/part-of: litmus
     #configmaps:
     #- name: openebs-target-network-delay
     #  mountPath: /mnt

--- a/charts/openebs/openebs-target-network-delay/rbac.yaml
+++ b/charts/openebs/openebs-target-network-delay/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: target-network-delay-sa
+    app.kubernetes.io/part-of: litmus
 ---
 # Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ metadata:
   name: target-network-delay-sa
   labels:
     name: target-network-delay-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io"]
   resources: ["pods","pods/exec","pods/log","events","jobs","configmaps","secrets","services","persistentvolumeclaims","storageclasses","persistentvolumes","chaosexperiments","chaosresults","chaosengines"]
@@ -25,6 +27,7 @@ metadata:
   name: target-network-delay-sa
   labels:
     name: target-network-delay-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-target-network-loss/experiment.yaml
+++ b/charts/openebs/openebs-target-network-loss/experiment.yaml
@@ -82,6 +82,7 @@ spec:
 
     labels:
       name: openebs-target-network-loss
+      app.kubernetes.io/part-of: litmus
     #configmaps:
     #- name: openebs-target-network-loss
     #  mountPath: /mnt

--- a/charts/openebs/openebs-target-network-loss/rbac.yaml
+++ b/charts/openebs/openebs-target-network-loss/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: target-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 ---
 # Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ metadata:
   name: target-network-loss-sa
   labels:
     name: target-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io"]
   resources: ["pods","pods/exec","pods/log","events","jobs","configmaps","secrets","services","persistentvolumeclaims","storageclasses","persistentvolumes","chaosexperiments","chaosresults","chaosengines"]
@@ -25,6 +27,7 @@ metadata:
   name: target-network-loss-sa
   labels:
     name: target-network-loss-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openebs/openebs-target-pod-failure/experiment.yaml
+++ b/charts/openebs/openebs-target-pod-failure/experiment.yaml
@@ -93,6 +93,7 @@ spec:
 
     labels:
       name: openebs-target-pod-failure
+      app.kubernetes.io/part-of: litmus
     #configmaps:
     #- name: openebs-target-pod-failure
     #  mountPath: /mnt

--- a/charts/openebs/openebs-target-pod-failure/rbac.yaml
+++ b/charts/openebs/openebs-target-pod-failure/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   labels:
     name: target-pod-failure-sa
+    app.kubernetes.io/part-of: litmus
 ---
 # Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ metadata:
   name: target-pod-failure-sa
   labels:
     name: target-pod-failure-sa
+    app.kubernetes.io/part-of: litmus
 rules:
 - apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io"]
   resources: ["pods","jobs","pods/log","deployments","pods/exec","events","chaosexperiments","chaosresults","chaosengines","configmaps","secrets","services","persistentvolumeclaims","storageclasses","persistentvolumes"]
@@ -28,6 +30,7 @@ metadata:
   name: target-pod-failure-sa
   labels:
     name: target-pod-failure-sa
+    app.kubernetes.io/part-of: litmus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
- Adds one of the recommended kubernetes labels to the experiment CRs so that they are propagated to experiment pods, results & helper pods. 

Signed-off-by: ksatchit <karthik.s@mayadata.io>