### PR TITLE
add AKS as a tested platform

### DIFF
--- a/charts/generic/node-io-stress/node-io-stress.chartserviceversion.yaml
+++ b/charts/generic/node-io-stress/node-io-stress.chartserviceversion.yaml
@@ -24,6 +24,7 @@ spec:
   platforms:
     - GKE
     - EKS
+    - AKS
   maturity: alpha
   chaosType: infra
   maintainers:

--- a/charts/generic/pod-autoscaler/pod-autoscaler.chartserviceversion.yaml
+++ b/charts/generic/pod-autoscaler/pod-autoscaler.chartserviceversion.yaml
@@ -23,6 +23,7 @@ spec:
     - GKE
     - EKS
     - Minikube
+    - AKS
   maturity: alpha
   chaosType: infra
   maintainers:

--- a/charts/generic/pod-io-stress/pod-io-stress.chartserviceversion.yaml
+++ b/charts/generic/pod-io-stress/pod-io-stress.chartserviceversion.yaml
@@ -22,6 +22,7 @@ spec:
     - Packet(Kubeadm)
     - Minikube
     - EKS
+    - AKS
   maturity: alpha
   maintainers:
     - name: Udit Gaurav


### PR DESCRIPTION
Signed-off-by: ToruMakabe <tomakabe@microsoft.com>

fixes litmuschaos/litmus#2275

Add AKS as a tested platform to 3 new experiments (pod-autoscaler, pod-io-stress, node-io-stress)

* AKS 1.18.8
* Litmus 1.9.0
* Test results are [here](https://gist.github.com/ToruMakabe/d3bfe357a02eb6650af53e6e189094ac)