### PR TITLE
add(node-poweroff): Added node-poweroff experiment (based on node-restart)

### DIFF
--- a/charts/generic/node-poweroff/engine.yaml
+++ b/charts/generic/node-poweroff/engine.yaml
@@ -1,0 +1,39 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  # It can be true/false
+  annotationCheck: 'false'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ''
+  appinfo:
+    appns: 'default'
+    applabel: 'app=nginx'
+    appkind: 'deployment'
+  chaosServiceAccount: node-poweroff-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-poweroff
+      spec:
+        components:
+          nodeSelector: 
+            # provide the node labels
+            kubernetes.io/hostname: 'node02'  
+          env:
+             # ENTER THE TARGET NODE NAME
+            - name: TARGET_NODE
+              value: ''
+
+            # ENTER THE TARGET NODE IP
+            - name: TARGET_NODE_IP
+              value: ''
+
+             # ENTER THE USER TO BE USED FOR SSH AUTH
+            - name: SSH_USER
+              value: ''

--- a/charts/generic/node-poweroff/experiment.yaml
+++ b/charts/generic/node-poweroff/experiment.yaml
@@ -1,0 +1,94 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    poweroff node
+kind: ChaosExperiment
+metadata:
+  name: node-poweroff
+  version: 0.1.0
+  labels:
+    name: node-poweroff
+    app.kubernetes.io/part-of: litmus
+    app.kubernetes.io/component: chaosexperiment
+    app.kubernetes.io/version: latest
+spec:
+  definition:
+    scope: Cluster
+    permissions:
+      - apiGroups:
+          - ""
+          - "batch"
+          - "apps"
+          - "litmuschaos.io"
+        resources:
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "events"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+          - "secrets"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+      - apiGroups:
+          - ""
+        resources:
+          - "nodes"
+        verbs:
+          - "get"
+          - "list"
+    image: "litmuschaos/go-runner:latest"
+    imagePullPolicy: Always
+    args:
+    - -c
+    - ./experiments -name node-restart
+    command:
+    - /bin/bash
+    env:
+    - name: SSH_USER
+      value: 'root'
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '360'
+
+    - name: EXPERIMENT_NAME
+      value: 'node-poweroff'
+
+    - name: REBOOT_COMMAND
+      value: '-o ServerAliveInterval=1 -o ServerAliveCountMax=1 "sudo systemctl poweroff --force --force" ; true'
+
+    # Period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    # PROVIDE THE LIB HERE
+    # ONLY LITMUS SUPPORTED
+    - name: LIB
+      value: 'litmus'
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "litmuschaos/go-runner:latest"
+
+    # ENTER THE TARGET NODE NAME
+    - name: TARGET_NODE
+      value: ''
+
+    # ENTER THE TARGET NODE IP
+    - name: TARGET_NODE_IP
+      value: ''
+
+    labels:
+      name: node-poweroff
+      app.kubernetes.io/part-of: litmus
+      app.kubernetes.io/component: experiment-job
+      app.kubernetes.io/version: latest
+    secrets:
+      - name: id-rsa
+        mountPath: /mnt/

--- a/charts/generic/node-poweroff/node-poweroff.chartserviceversion.yaml
+++ b/charts/generic/node-poweroff/node-poweroff.chartserviceversion.yaml
@@ -19,9 +19,7 @@ spec:
     - Node
     - SSH
   platforms:
-    - GKE
-    - EKS
-    - AKS
+    - KVM/LibVirt based K8s
   maturity: alpha
   chaosType: infra
   maintainers:

--- a/charts/generic/node-poweroff/node-poweroff.chartserviceversion.yaml
+++ b/charts/generic/node-poweroff/node-poweroff.chartserviceversion.yaml
@@ -1,0 +1,41 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  createdAt: 2019-01-28T10:28:08Z
+  name: node-poweroff
+  version: 0.1.0
+  annotations:
+    categories: Kubernetes
+    vendor: CNCF
+    support: https://slack.kubernetes.io/
+spec:
+  displayName: node-poweroff
+  categoryDescription: |
+    Node poweroff contains chaos experiment to poweroff a node via SSH.
+  keywords:
+    - Kubernetes
+    - Poweroff
+    - State
+    - Node
+    - SSH
+  platforms:
+    - GKE
+    - EKS
+    - AKS
+  maturity: alpha
+  chaosType: infra
+  maintainers:
+    - name: jordigilh
+      email: jordi.gil@gmail.com
+  minKubeVersion: 1.12.0
+  provider:
+    name: Mayadata
+  links:
+    - name: Source Code
+      url: https://github.com/litmuschaos/litmus-go/tree/master/experiments/generic/node-restart
+    - name: Documentation
+      url: https://docs.litmuschaos.io/docs/node-restart
+  icon: 
+    - url: 
+      mediatype: ""
+  chaosexpcrdlink: https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-poweroff/experiment.yaml

--- a/charts/generic/node-poweroff/rbac.yaml
+++ b/charts/generic/node-poweroff/rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-poweroff-sa
+  namespace: default
+  labels:
+    name: node-poweroff-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-poweroff-sa
+  labels:
+    name: node-poweroff-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","jobs","secrets","events","chaosengines","pods/log","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-poweroff-sa
+  labels:
+    name: node-poweroff-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-poweroff-sa
+subjects:
+- kind: ServiceAccount
+  name: node-poweroff-sa
+  namespace: default


### PR DESCRIPTION
This PR adds the yaml manifests for the `node-poweroff` experiment. This experiment relies on the `node-restart` changes introduced in the `go-runner` in 1.10.0.

@machacekondra please review.

Cheers,

/Jordi