### PR TITLE
chore(experiment): updating the lib and socketPath

### DIFF
--- a/charts/generic/container-kill/engine.yaml
+++ b/charts/generic/container-kill/engine.yaml
@@ -23,10 +23,6 @@ spec:
       spec:
         components:
           env:
-            # specify the name of the container to be killed
-            - name: TARGET_CONTAINER
-              value: 'nginx'
-
             # provide the chaos interval
             - name: CHAOS_INTERVAL
               value: '10'
@@ -36,13 +32,12 @@ spec:
               value: '20'
 
             # provide the name of container runtime
-            # it supports docker, containerd, crio
-            # default to docker
+            # for litmus LIB, it supports docker, containerd, crio
+            # for pumba LIB, it supports docker only
             - name: CONTAINER_RUNTIME
               value: 'docker'
 
             # provide the socket file path
-            # applicable only for containerd runtime
             - name: SOCKET_PATH
-              value: '/run/containerd/containerd.sock'
+              value: '/var/run/docker.sock'
               

--- a/charts/generic/container-kill/experiment.yaml
+++ b/charts/generic/container-kill/experiment.yaml
@@ -51,6 +51,7 @@ spec:
     - name: RAMP_TIME
       value: ''
 
+    # lib can be litmus or pumba
     - name: LIB
       value: 'litmus'
       
@@ -62,13 +63,12 @@ spec:
       value: '10'
 
     # provide the socket file path
-    # applicable only for containerd and crio runtime
     - name: SOCKET_PATH
-      value: '/run/containerd/containerd.sock'
+      value: '/var/run/docker.sock'
 
     # provide the name of container runtime
-    # it supports docker, containerd, crio
-    # default to docker
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
     - name: CONTAINER_RUNTIME
       value: 'docker'
 
@@ -88,10 +88,6 @@ spec:
     - name: SEQUENCE
       value: 'parallel'
 
-    securityContext:
-      containerSecurityContext:
-        privileged: true
-    
     labels:
       name: container-kill
       app.kubernetes.io/part-of: litmus

--- a/charts/generic/pod-network-corruption/engine.yaml
+++ b/charts/generic/pod-network-corruption/engine.yaml
@@ -24,10 +24,6 @@ spec:
       spec:
         components:
           env:
-           #Container name where chaos has to be injected
-            - name: TARGET_CONTAINER
-              value: 'nginx' 
-
             - name: LIB_IMAGE
               value: 'litmuschaos/go-runner:latest'
 
@@ -39,12 +35,11 @@ spec:
               value: '60' # in seconds
 
             # provide the name of container runtime
-            # it supports docker, containerd, crio
-            # default to docker
+            # for litmus LIB, it supports docker, containerd, crio
+            # for pumba LIB, it supports docker only
             - name: CONTAINER_RUNTIME
               value: 'docker'
 
             # provide the socket file path
-            # applicable only for containerd and crio runtime
             - name: SOCKET_PATH
-              value: '/run/containerd/containerd.sock'
+              value: '/var/run/docker.sock'

--- a/charts/generic/pod-network-corruption/experiment.yaml
+++ b/charts/generic/pod-network-corruption/experiment.yaml
@@ -65,7 +65,8 @@ spec:
     # Time period to wait before and after injection of chaos in sec
     - name: RAMP_TIME
       value: ''
-
+   
+    # lib can be litmus or pumba
     - name: LIB
       value: 'litmus'
 
@@ -77,8 +78,8 @@ spec:
       value: ''
 
     # provide the name of container runtime
-    # it supports docker, containerd, crio
-    # default to docker
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
     - name: CONTAINER_RUNTIME
       value: 'docker'
 
@@ -93,9 +94,8 @@ spec:
       value: ''
 
     # provide the socket file path
-    # applicable only for containerd and crio runtime
     - name: SOCKET_PATH
-      value: '/run/containerd/containerd.sock'
+      value: '/var/run/docker.sock'
 
     ## it defines the sequence of chaos execution for multiple target pods
     ## supported values: serial, parallel

--- a/charts/generic/pod-network-duplication/engine.yaml
+++ b/charts/generic/pod-network-duplication/engine.yaml
@@ -37,18 +37,13 @@ spec:
 
             - name: NETWORK_PACKET_DUPLICATION_PERCENTAGE
               value: '100'
-            
-            #If not provided it will take the first container of the target pod
-            - name: TARGET_CONTAINER
-              value: ''
-
+  
             # provide the name of container runtime
-            # it supports docker, containerd, crio
-            # default to docker
+            # for litmus LIB, it supports docker, containerd, crio
+            # for pumba LIB, it supports docker only
             - name: CONTAINER_RUNTIME
               value: 'docker'
 
             # provide the socket file path
-            # applicable only for containerd and crio runtime
             - name: SOCKET_PATH
-              value: '/run/containerd/containerd.sock'
+              value: '/var/run/docker.sock'

--- a/charts/generic/pod-network-duplication/experiment.yaml
+++ b/charts/generic/pod-network-duplication/experiment.yaml
@@ -59,6 +59,7 @@ spec:
     - name: NETWORK_PACKET_DUPLICATION_PERCENTAGE
       value: '100' # in percentage
 
+    # lib can be litmus or pumba
     - name: LIB
       value: 'litmus'   
 
@@ -73,8 +74,8 @@ spec:
       value: 'litmuschaos/go-runner:latest'
 
     # provide the name of container runtime
-    # it supports docker, containerd, crio
-    # default to docker
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
     - name: CONTAINER_RUNTIME
       value: 'docker'
 
@@ -89,9 +90,8 @@ spec:
       value: ''
 
     # provide the socket file path
-    # applicable only for containerd and crio runtime
     - name: SOCKET_PATH
-      value: '/run/containerd/containerd.sock'
+      value: '/var/run/docker.sock'
 
     ## it defines the sequence of chaos execution for multiple target pods
     ## supported values: serial, parallel

--- a/charts/generic/pod-network-latency/engine.yaml
+++ b/charts/generic/pod-network-latency/engine.yaml
@@ -24,10 +24,6 @@ spec:
       spec:
         components:
           env:
-            #Container name where chaos has to be injected
-            - name: TARGET_CONTAINER
-              value: 'nginx' 
-
             #Network interface inside target container
             - name: NETWORK_INTERFACE
               value: 'eth0'     
@@ -42,12 +38,11 @@ spec:
               value: '60' # in seconds
 
             # provide the name of container runtime
-            # it supports docker, containerd, crio
-            # default to docker
+            # for litmus LIB, it supports docker, containerd, crio
+            # for pumba LIB, it supports docker only
             - name: CONTAINER_RUNTIME
               value: 'docker'
 
             # provide the socket file path
-            # applicable only for containerd and crio runtime
             - name: SOCKET_PATH
-              value: '/run/containerd/containerd.sock'
+              value: '/var/run/docker.sock'

--- a/charts/generic/pod-network-latency/experiment.yaml
+++ b/charts/generic/pod-network-latency/experiment.yaml
@@ -66,6 +66,7 @@ spec:
     - name: RAMP_TIME
       value: ''
 
+    # lib can be litmus or pumba
     - name: LIB
       value: 'litmus'
 
@@ -77,8 +78,8 @@ spec:
       value: ''
 
     # provide the name of container runtime
-    # it supports docker, containerd, crio
-    # default to docker
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
     - name: CONTAINER_RUNTIME
       value: 'docker'
 
@@ -93,9 +94,8 @@ spec:
       value: ''
 
     # provide the socket file path
-    # applicable only for containerd and crio runtime
     - name: SOCKET_PATH
-      value: '/run/containerd/containerd.sock'
+      value: '/var/run/docker.sock'
 
     ## it defines the sequence of chaos execution for multiple target pods
     ## supported values: serial, parallel

--- a/charts/generic/pod-network-loss/engine.yaml
+++ b/charts/generic/pod-network-loss/engine.yaml
@@ -25,10 +25,6 @@ spec:
       spec:
         components:
           env:
-            #Container name where chaos has to be injected              
-            - name: TARGET_CONTAINER
-              value: 'nginx' 
-
             - name: LIB_IMAGE
               value: 'litmuschaos/go-runner:latest'
 
@@ -43,13 +39,12 @@ spec:
               value: '60' # in seconds
 
             # provide the name of container runtime
-            # it supports docker, containerd, crio
-            # default to docker
+            # for litmus LIB, it supports docker, containerd, crio
+            # for pumba LIB, it supports docker only
             - name: CONTAINER_RUNTIME
               value: 'docker'
 
             # provide the socket file path
-            # applicable only for containerd and crio runtime
             - name: SOCKET_PATH
-              value: '/run/containerd/containerd.sock'
+              value: '/var/run/docker.sock'
             

--- a/charts/generic/pod-network-loss/experiment.yaml
+++ b/charts/generic/pod-network-loss/experiment.yaml
@@ -66,6 +66,7 @@ spec:
     - name: RAMP_TIME
       value: ''
 
+    # it can be litmus or pumba
     - name: LIB
       value: 'litmus'
 
@@ -77,8 +78,8 @@ spec:
       value: ''
 
     # provide the name of container runtime
-    # it supports docker, containerd, crio
-    # default to docker
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
     - name: CONTAINER_RUNTIME
       value: 'docker'
 
@@ -93,9 +94,8 @@ spec:
       value: ''
 
     # provide the socket file path
-    # applicable only for containerd and crio runtime
     - name: SOCKET_PATH
-      value: '/run/containerd/containerd.sock'
+      value: '/var/run/docker.sock'
 
     ## it defines the sequence of chaos execution for multiple target pods
     ## supported values: serial, parallel


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Added pumba `LIB` separately. 
    - litmus `LIB` supports all the three container runtime
    - pumba `lib` will only support docker runtime
- Default LIB is litmus and container-runtime is docker(passed the corresponding socket file path). It needs to be overridden from chaosengine for anything other than this.
- Removed securityContext from container-kill CR, as we are not using the same.