### PR TITLE
(fix) Add non-root images for all k8s executors for chaos workflows. 

### DIFF
--- a/service-accounts/argowf-chaos-admin.yaml
+++ b/service-accounts/argowf-chaos-admin.yaml
@@ -63,7 +63,7 @@ spec:
                           - name: REPORT_ENDPOINT
                             value: 'none'
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/chaosengine.yaml -n {{workflow.parameters.adminModeNamespace}} | echo "sleeping for 120s" | sleep 120 ']
 
@@ -104,12 +104,12 @@ spec:
                       imagePullPolicy: Always
                       name: nginx-bench
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/bench.yaml -n {{workflow.parameters.appNamespace}}']
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [' sleep 20 | kubectl delete chaosengine nginx-chaos -n {{workflow.parameters.adminModeNamespace}}']

--- a/workflows/k8-calico-node/workflow.yaml
+++ b/workflows/k8-calico-node/workflow.yaml
@@ -95,7 +95,7 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/createChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']
 
@@ -145,6 +145,6 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [' sleep 20 | kubectl delete  -f /tmp/deleteChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']

--- a/workflows/k8-kiam/workflow.yaml
+++ b/workflows/k8-kiam/workflow.yaml
@@ -95,7 +95,7 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/createChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']
 
@@ -145,6 +145,6 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [' sleep 20 | kubectl delete  -f /tmp/deleteChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']

--- a/workflows/k8-pod-delete/workflow.yaml
+++ b/workflows/k8-pod-delete/workflow.yaml
@@ -58,7 +58,7 @@ spec:
     
     - name: install-chaos-experiments
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/k8-pod-delete/experiments.yaml -n
@@ -66,7 +66,7 @@ spec:
     
     - name: install-chaos-rbac
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/k8-pod-delete/rbac.yaml -n
@@ -118,7 +118,7 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/createChaosEngine.yaml -n {{workflow.parameters.appNamespace}} | echo "sleeping for 60s" | sleep 60 ']
 
@@ -168,13 +168,13 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [' sleep 20 | kubectl delete  -f /tmp/deleteChaosEngine.yaml -n {{workflow.parameters.appNamespace}} | echo "sleeping for 60s" | sleep 60 ']
        
     - name: revert-chaos-experiments
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           - "kubectl delete -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/k8-pod-delete/experiments.yaml -n
@@ -182,7 +182,7 @@ spec:
     
     - name: revert-chaos-rbac
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           - "kubectl delete -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/k8-pod-delete/rbac.yaml -n

--- a/workflows/k8-service-kill/workflow.yaml
+++ b/workflows/k8-service-kill/workflow.yaml
@@ -95,7 +95,7 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/createChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']
 
@@ -145,6 +145,6 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [' sleep 20 | kubectl delete  -f /tmp/deleteChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']

--- a/workflows/k8-wavefront-collector/workflow.yaml
+++ b/workflows/k8-wavefront-collector/workflow.yaml
@@ -95,7 +95,7 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: ['kubectl apply -f /tmp/createChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']
 
@@ -145,6 +145,6 @@ spec:
                           - name: TEST_NAMESPACE
                             value: {{workflow.parameters.appCurrentNamespace}}
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [' sleep 20 | kubectl delete  -f /tmp/deleteChaosEngine.yaml -n {{workflow.parameters.appCurrentNamespace}} | echo "sleeping for 60s" | sleep 60 ']

--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -34,7 +34,7 @@ spec:
 
     - name: install-chaos-experiments
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.12.0?file=charts/generic/experiments.yaml -n
@@ -230,7 +230,7 @@ spec:
 
     - name: revert-kube-proxy-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           - "kubectl delete chaosengines --all -n

--- a/workflows/kube-proxy-all/workflow_cron.yaml
+++ b/workflows/kube-proxy-all/workflow_cron.yaml
@@ -37,7 +37,7 @@ spec:
 
       - name: install-chaos-experiments
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.12.0?file=charts/generic/experiments.yaml -n
@@ -233,7 +233,7 @@ spec:
 
       - name: revert-kube-proxy-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             - "kubectl delete chaosengines --all -n

--- a/workflows/namespaced-scope-chaos/workflow.yaml
+++ b/workflows/namespaced-scope-chaos/workflow.yaml
@@ -100,7 +100,7 @@ spec:
                     labels:
                       name: pod-delete
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         resources:
           limits:
             memory: 128Mi
@@ -163,7 +163,7 @@ spec:
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         resources:
           limits:
             memory: 128Mi

--- a/workflows/namespaced-scope-chaos/workflow_cron.yaml
+++ b/workflows/namespaced-scope-chaos/workflow_cron.yaml
@@ -104,7 +104,7 @@ spec:
                       labels:
                         name: pod-delete
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           resources:
             limits:
               memory: 128Mi
@@ -167,7 +167,7 @@ spec:
 
       - name: revert-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           resources:
             limits:
               memory: 128Mi

--- a/workflows/node-cpu-hog/workflow.yaml
+++ b/workflows/node-cpu-hog/workflow.yaml
@@ -101,7 +101,7 @@ spec:
                     labels:
                       name: node-cpu-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -146,7 +146,7 @@ spec:
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [

--- a/workflows/node-cpu-hog/workflow_cron.yaml
+++ b/workflows/node-cpu-hog/workflow_cron.yaml
@@ -105,7 +105,7 @@ spec:
                       labels:
                         name: node-cpu-hog
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [
@@ -150,7 +150,7 @@ spec:
 
       - name: revert-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [

--- a/workflows/node-memory-hog/workflow.yaml
+++ b/workflows/node-memory-hog/workflow.yaml
@@ -101,7 +101,7 @@ spec:
                     labels:
                       name: node-memory-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -146,7 +146,7 @@ spec:
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [

--- a/workflows/node-memory-hog/workflow_cron.yaml
+++ b/workflows/node-memory-hog/workflow_cron.yaml
@@ -98,7 +98,7 @@ spec:
                       labels:
                         name: node-memory-hog
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [
@@ -140,7 +140,7 @@ spec:
           args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
       - name: revert-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [

--- a/workflows/pod-cpu-hog/workflow.yaml
+++ b/workflows/pod-cpu-hog/workflow.yaml
@@ -95,7 +95,7 @@ spec:
                     labels:
                       name: pod-cpu-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -147,7 +147,7 @@ spec:
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [

--- a/workflows/pod-cpu-hog/workflow_cron.yaml
+++ b/workflows/pod-cpu-hog/workflow_cron.yaml
@@ -99,7 +99,7 @@ spec:
                       labels:
                         name: pod-cpu-hog
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [
@@ -151,7 +151,7 @@ spec:
 
       - name: revert-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [

--- a/workflows/pod-delete/workflow.yaml
+++ b/workflows/pod-delete/workflow.yaml
@@ -101,7 +101,7 @@ spec:
                     labels:
                       name: pod-delete
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -147,7 +147,7 @@ spec:
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [

--- a/workflows/pod-delete/workflow_cron.yaml
+++ b/workflows/pod-delete/workflow_cron.yaml
@@ -105,7 +105,7 @@ spec:
                       labels:
                         name: pod-delete
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [
@@ -151,7 +151,7 @@ spec:
 
       - name: revert-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [

--- a/workflows/pod-memory-hog/workflow.yaml
+++ b/workflows/pod-memory-hog/workflow.yaml
@@ -96,7 +96,7 @@ spec:
                     labels:
                       name: pod-memory-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -148,7 +148,7 @@ spec:
 
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [

--- a/workflows/pod-memory-hog/workflow_cron.yaml
+++ b/workflows/pod-memory-hog/workflow_cron.yaml
@@ -100,7 +100,7 @@ spec:
                       labels:
                         name: pod-memory-hog
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [
@@ -152,7 +152,7 @@ spec:
 
       - name: revert-chaos
         container:
-          image: lachlanevenson/k8s-kubectl
+          image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
             [

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -134,7 +134,7 @@ spec:
                     labels:
                       name: pod-delete
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -226,7 +226,7 @@ spec:
                     labels:
                       name: pod-cpu-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -320,7 +320,7 @@ spec:
                     labels:
                       name: pod-memory-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -418,7 +418,7 @@ spec:
                     labels:
                       name: pod-network-loss
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [ "kubectl apply -f /tmp/pod-network-loss.yaml -n {{workflow.parameters.adminModeNamespace}}",]
     
@@ -733,7 +733,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -138,7 +138,7 @@ spec:
                     labels:
                       name: pod-delete
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -230,7 +230,7 @@ spec:
                     labels:
                       name: pod-cpu-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -324,7 +324,7 @@ spec:
                     labels:
                       name: pod-memory-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -422,7 +422,7 @@ spec:
                     labels:
                       name: pod-network-loss
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [ "kubectl apply -f /tmp/pod-network-loss.yaml -n {{workflow.parameters.adminModeNamespace}}",]
     
@@ -737,7 +737,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -134,7 +134,7 @@ spec:
                     labels:
                       name: pod-delete
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -226,7 +226,7 @@ spec:
                     labels:
                       name: pod-cpu-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -320,7 +320,7 @@ spec:
                     labels:
                       name: pod-memory-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -418,7 +418,7 @@ spec:
                     labels:
                       name: pod-network-loss
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [ "kubectl apply -f /tmp/pod-network-loss.yaml -n {{workflow.parameters.adminModeNamespace}}",]
         
@@ -727,7 +727,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -140,7 +140,7 @@ spec:
                     labels:
                       name: pod-delete
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -232,7 +232,7 @@ spec:
                     labels:
                       name: pod-cpu-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -326,7 +326,7 @@ spec:
                     labels:
                       name: pod-memory-hog
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
           [
@@ -424,7 +424,7 @@ spec:
                     labels:
                       name: pod-network-loss
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: [ "kubectl apply -f /tmp/pod-network-loss.yaml -n {{workflow.parameters.adminModeNamespace}}",]
         
@@ -732,7 +732,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 


### PR DESCRIPTION
This PR is fixing issue nom #421.
Add non-root images for all k8s executors for chaos workflows. 