### PR TITLE
chore(workflow): Updating the http schema and few minor fixes

### DIFF
--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -233,5 +233,5 @@ spec:
         image: alpine/k8s:1.18.2
         command: [sh, -c]
         args:
-          - "kubectl delete chaosengines --all -n
+          - "kubectl delete chaosengines kube-proxy-node-cpu-hog kube-proxy-pod-memory-hog-chaos kube-proxy-pod-cpu-hog-chaos kube-proxy-node-memory-hog-chaos kube-proxy-pod-delete-chaos -n
             {{workflow.parameters.adminModeNamespace}}"

--- a/workflows/kube-proxy-all/workflow_cron.yaml
+++ b/workflows/kube-proxy-all/workflow_cron.yaml
@@ -236,5 +236,5 @@ spec:
           image: alpine/k8s:1.18.2
           command: [sh, -c]
           args:
-            - "kubectl delete chaosengines --all -n
+            - "kubectl delete chaosengines kube-proxy-node-cpu-hog kube-proxy-pod-memory-hog-chaos kube-proxy-pod-cpu-hog-chaos kube-proxy-node-memory-hog-chaos kube-proxy-pod-delete-chaos -n
               {{workflow.parameters.adminModeNamespace}}"

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -110,6 +110,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -182,6 +183,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -255,6 +257,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -329,6 +332,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -405,6 +409,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 1
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -50,7 +50,7 @@ spec:
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} | sleep 30"
+            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
 
     - name: pod-cpu-hog
       inputs:
@@ -83,6 +83,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -100,16 +101,15 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -118,7 +118,7 @@ spec:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
-                              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"  
+                              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
         
       container:
         image: litmuschaos/litmus-checker:latest
@@ -155,6 +155,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -172,16 +173,15 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -228,15 +228,16 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/catalogue"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 5
-                            interval: 2
-                            retry: 2
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-benchmark"
                           type: "cmdProbe"
@@ -245,23 +246,21 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
-                
                             # set chaos interval (in sec) as desired
                             - name: CHAOS_INTERVAL
                               value: '10'
-                
                             # pod failures without '--force' & default terminationGracePeriodSeconds
                             - name: FORCE
                               value: 'false'
@@ -303,15 +302,16 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/cards"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 2
-                            interval: 1
-                            retry: 1
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-benchmark"
                           type: "cmdProbe"
@@ -320,22 +320,20 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
-                            
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
-                            
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
@@ -398,23 +396,22 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 1
                         components:
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'
-                
                             - name: TARGET_CONTAINER
                               value: ''
                             - name: TOTAL_CHAOS_DURATION
-                              value: '60'                            
+                              value: '30'                            
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -237,7 +237,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1
@@ -312,7 +312,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -241,7 +241,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1
@@ -316,7 +316,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -114,6 +114,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -186,6 +187,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -259,6 +261,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -333,6 +336,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -409,6 +413,7 @@ spec:
                             retry: 2
                             initialDelaySeconds: 1
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -54,7 +54,7 @@ spec:
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} | sleep 30"
+            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
     
     - name: pod-cpu-hog
       inputs:
@@ -87,6 +87,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -95,7 +96,7 @@ spec:
                           runProperties:
                             probeTimeout: 2
                             interval: 1
-                            retry: 1
+                            retry: 2
                             probePollingInterval: 1
                         - name: "check-benchmark"
                           type: "cmdProbe"
@@ -104,16 +105,15 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -122,7 +122,7 @@ spec:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
-                              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"  
+                              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
         
       container:
         image: litmuschaos/litmus-checker:latest
@@ -159,6 +159,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -167,7 +168,7 @@ spec:
                           runProperties:
                             probeTimeout: 2
                             interval: 1
-                            retry: 1
+                            retry: 2
                             probePollingInterval: 1
                         - name: "check-benchmark"
                           type: "cmdProbe"
@@ -176,23 +177,22 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
-                              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"  
+                              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"
                             
       container:
         image: litmuschaos/litmus-checker:latest
@@ -232,15 +232,16 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/catalogue"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 2
-                            interval: 1
-                            retry: 1
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-benchmark"
                           type: "cmdProbe"
@@ -249,23 +250,21 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
-                
                             # set chaos interval (in sec) as desired
                             - name: CHAOS_INTERVAL
                               value: '10'
-                
                             # pod failures without '--force' & default terminationGracePeriodSeconds
                             - name: FORCE
                               value: 'false'
@@ -307,15 +306,16 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/cards"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 2
-                            interval: 1
-                            retry: 2
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-benchmark"
                           type: "cmdProbe"
@@ -324,22 +324,20 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
-                            
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
-                            
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
@@ -402,23 +400,22 @@ spec:
                             comparator:
                               type: "int" # supports: string, int, float
                               criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
-                              value: "500"
+                              value: "100"
                             source: "inline" # it can be “inline” or any image
                           mode: "Edge"
                           runProperties:
                             probeTimeout: 2
-                            interval: 2
-                            retry: 1
+                            interval: 1
+                            retry: 2
                             initialDelaySeconds: 1
                         components:
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'
-                
                             - name: TARGET_CONTAINER
                               value: ''
                             - name: TOTAL_CHAOS_DURATION
-                              value: '60'                            
+                              value: '30'                            
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -50,7 +50,7 @@ spec:
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} | sleep 30"
+            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
         
     - name: pod-cpu-hog
       inputs:
@@ -83,6 +83,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -96,18 +97,17 @@ spec:
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -153,6 +153,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -166,26 +167,24 @@ spec:
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' # in seconds
-
                             - name: CHAOS_KILL_COMMAND
-                              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"  
+                              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"
                             
       container:
         image: litmuschaos/litmus-checker:latest
@@ -225,38 +224,37 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/catalogue"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 3
-                            interval: 1
-                            retry: 2
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
-                
                             # set chaos interval (in sec) as desired
                             - name: CHAOS_INTERVAL
                               value: '10'
-                
                             # pod failures without '--force' & default terminationGracePeriodSeconds
                             - name: FORCE
                               value: 'false'
@@ -299,37 +297,36 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/cards"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 2
-                            interval: 1
-                            retry: 2
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
-                            
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
-                            
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
@@ -388,25 +385,24 @@ spec:
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'
-                
                             - name: TARGET_CONTAINER
                               value: ''
                             - name: TOTAL_CHAOS_DURATION
-                              value: '60'                            
+                              value: '30'                            
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -233,7 +233,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1
@@ -307,7 +307,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -108,6 +108,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -178,6 +179,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -249,6 +251,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -322,6 +325,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -396,6 +400,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -56,7 +56,7 @@ spec:
         command: [sh, -c]
         args:
           - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} | sleep 30"
+            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
         
     - name: pod-cpu-hog
       inputs:
@@ -89,6 +89,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -102,18 +103,17 @@ spec:
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -122,7 +122,7 @@ spec:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
-                              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"  
+                              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
         
       container:
         image: litmuschaos/litmus-checker:latest
@@ -159,6 +159,7 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
@@ -172,18 +173,17 @@ spec:
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -230,38 +230,37 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/catalogue"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 2
-                            interval: 1
-                            retry: 2
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
-                
                             # set chaos interval (in sec) as desired
                             - name: CHAOS_INTERVAL
                               value: '10'
-                
                             # pod failures without '--force' & default terminationGracePeriodSeconds
                             - name: FORCE
                               value: 'false'
@@ -304,37 +303,36 @@ spec:
                           httpProbe/inputs:
                             url: "http://front-end.sock-shop.svc.cluster.local:80/cards"
                             insecureSkipVerify: false
+                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 2
-                            interval: 1
-                            retry: 2
+                            probeTimeout: 10
+                            interval: 12
+                            retry: 3
                             probePollingInterval: 1
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
-                            
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
-                            
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
@@ -393,25 +391,24 @@ spec:
                         - name: "check-probe-success"
                           type: "promProbe"
                           promProbe/inputs:
-                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            endpoint: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
                             query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
                             comparator:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
-                              value: "500"
+                              value: "100"
                           mode: "Edge"
                           runProperties:  
-                            probeTimeout: 5
-                            interval: 5
-                            retry: 1
+                            probeTimeout: 2
+                            interval: 1
+                            retry: 2
                         components:
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'
-                
                             - name: TARGET_CONTAINER
                               value: ''
                             - name: TOTAL_CHAOS_DURATION
-                              value: '60'                            
+                              value: '30'                            
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -239,7 +239,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1
@@ -313,7 +313,7 @@ spec:
                                 responseCode: "200"
                           mode: "Continuous"
                           runProperties:
-                            probeTimeout: 10
+                            probeTimeout: 12
                             interval: 12
                             retry: 3
                             probePollingInterval: 1

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -114,6 +114,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -184,6 +185,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -255,6 +257,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -328,6 +331,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -402,6 +406,7 @@ spec:
                             interval: 1
                             retry: 2
                         components:
+                          experimentImage: "litmuschaos/go-runner:latest"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'


### PR DESCRIPTION
Updating the http and k8s probe schema and few minor fixes
 - Updating http schema (Response Timeout added)
 - Modified revert chaos for kube-proxy
 - Experiment and Runner updated to ```1.13.2``` version
 - Some platforms not able to load large value so reduced default QPS to 100 
 