### PR TITLE
chore(chaosengine): Removed monitoring from all experiments & appinfo from infra experiments

### DIFF
--- a/charts/cassandra/cassandra-pod-delete/ansible/engine.yaml
+++ b/charts/cassandra/cassandra-pod-delete/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: cassandra-pod-delete-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/cassandra/cassandra-pod-delete/engine.yaml
+++ b/charts/cassandra/cassandra-pod-delete/engine.yaml
@@ -15,7 +15,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: cassandra-pod-delete-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/coredns/coredns-pod-delete/engine.yaml
+++ b/charts/coredns/coredns-pod-delete/engine.yaml
@@ -15,7 +15,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: coredns-pod-delete-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/container-kill/ansible/engine.yaml
+++ b/charts/generic/container-kill/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: container-kill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
   experiments:

--- a/charts/generic/container-kill/engine.yaml
+++ b/charts/generic/container-kill/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: container-kill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
   experiments:

--- a/charts/generic/container-kill/engine_nginx_getstarted.yaml
+++ b/charts/generic/container-kill/engine_nginx_getstarted.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: container-kill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
   experiments:

--- a/charts/generic/disk-fill/ansible/engine.yaml
+++ b/charts/generic/disk-fill/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: disk-fill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/disk-fill/engine.yaml
+++ b/charts/generic/disk-fill/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: disk-fill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/disk-loss/engine.yaml
+++ b/charts/generic/disk-loss/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: disk-loss-sa
-  monitoring: false
   # It can be retain/delete
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/docker-service-kill/engine.yaml
+++ b/charts/generic/docker-service-kill/engine.yaml
@@ -15,7 +15,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: docker-service-kill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/k8-pod-delete/Cluster/engine-app-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-app-all-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Cluster/engine-app-count.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-app-count.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Cluster/engine-app-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-app-health.yaml
@@ -10,8 +10,7 @@ spec:
     appkind: 'deployment'
   annotationCheck: 'true'
   engineState: 'active'
-  chaosServiceAccount: chaos-admin
-  monitoring: false
+  chaosServiceAccount: chaos-admin 
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Cluster/engine-custom-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-custom-all-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Cluster/engine-custom-count.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-custom-count.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Cluster/engine-custom-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-custom-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Service/engine-app-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-app-all-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Service/engine-app-count.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-app-count.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Service/engine-app-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-app-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Service/engine-custom-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-custom-all-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Service/engine-custom-count.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-custom-count.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/Service/engine-custom-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-custom-health.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-pod-delete/engine.yaml
+++ b/charts/generic/k8-pod-delete/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/generic/k8-service-kill/engine.yaml
+++ b/charts/generic/k8-service-kill/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-service-kill

--- a/charts/generic/kubelet-service-kill/ansible/engine.yaml
+++ b/charts/generic/kubelet-service-kill/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: kubelet-service-kill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/kubelet-service-kill/engine.yaml
+++ b/charts/generic/kubelet-service-kill/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: kubelet-service-kill-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-cpu-hog/ansible/engine.yaml
+++ b/charts/generic/node-cpu-hog/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: node-cpu-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-cpu-hog/engine.yaml
+++ b/charts/generic/node-cpu-hog/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-cpu-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-drain/ansible/engine.yaml
+++ b/charts/generic/node-drain/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: node-drain-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-drain/engine.yaml
+++ b/charts/generic/node-drain/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-drain-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-io-stress/engine.yaml
+++ b/charts/generic/node-io-stress/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-io-stress-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-memory-hog/ansible/engine.yaml
+++ b/charts/generic/node-memory-hog/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: node-memory-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-memory-hog/engine.yaml
+++ b/charts/generic/node-memory-hog/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-memory-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-poweroff/engine.yaml
+++ b/charts/generic/node-poweroff/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-poweroff-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-restart/engine.yaml
+++ b/charts/generic/node-restart/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-restart-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/node-taint/engine.yaml
+++ b/charts/generic/node-taint/engine.yaml
@@ -10,12 +10,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   chaosServiceAccount: node-taint-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-autoscaler/engine.yaml
+++ b/charts/generic/pod-autoscaler/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-autoscaler-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-cpu-hog/ansible/engine.yaml
+++ b/charts/generic/pod-cpu-hog/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-cpu-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-cpu-hog/engine.yaml
+++ b/charts/generic/pod-cpu-hog/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-cpu-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-delete/ansible/engine.yaml
+++ b/charts/generic/pod-delete/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: pod-delete-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-delete/engine.yaml
+++ b/charts/generic/pod-delete/engine.yaml
@@ -13,7 +13,6 @@ spec:
   # It can be active/stop
   engineState: 'active'
   chaosServiceAccount: pod-delete-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-delete/engine_nginx_getstarted.yaml
+++ b/charts/generic/pod-delete/engine_nginx_getstarted.yaml
@@ -15,7 +15,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: pod-delete-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-io-stress/engine.yaml
+++ b/charts/generic/pod-io-stress/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-io-stress-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-memory-hog/ansible/engine.yaml
+++ b/charts/generic/pod-memory-hog/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-memory-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-memory-hog/engine.yaml
+++ b/charts/generic/pod-memory-hog/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-memory-hog-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/generic/pod-network-corruption/ansible/engine.yaml
+++ b/charts/generic/pod-network-corruption/ansible/engine.yaml
@@ -12,7 +12,6 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/generic/pod-network-corruption/engine.yaml
+++ b/charts/generic/pod-network-corruption/engine.yaml
@@ -10,7 +10,6 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/generic/pod-network-duplication/engine.yaml
+++ b/charts/generic/pod-network-duplication/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/generic/pod-network-latency/ansible/engine.yaml
+++ b/charts/generic/pod-network-latency/ansible/engine.yaml
@@ -12,7 +12,6 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/generic/pod-network-latency/engine.yaml
+++ b/charts/generic/pod-network-latency/engine.yaml
@@ -10,7 +10,6 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/generic/pod-network-loss/ansible/engine.yaml
+++ b/charts/generic/pod-network-loss/ansible/engine.yaml
@@ -13,7 +13,6 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/generic/pod-network-loss/engine.yaml
+++ b/charts/generic/pod-network-loss/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  monitoring: false
   appinfo: 
     appns: 'default'
     # FYI, To see app label, apply kubectl get pods --show-labels

--- a/charts/kafka/kafka-broker-disk-failure/engine.yaml
+++ b/charts/kafka/kafka-broker-disk-failure/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=cp-kafka'
     appkind: 'statefulset'
   chaosServiceAccount: kafka-broker-disk-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
   experiments:

--- a/charts/kafka/kafka-broker-pod-failure/ansible/engine.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/ansible/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=cp-kafka'
     appkind: 'statefulset'
   chaosServiceAccount: kafka-broker-pod-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
   experiments:

--- a/charts/kafka/kafka-broker-pod-failure/engine.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=cp-kafka'
     appkind: 'statefulset'
   chaosServiceAccount: kafka-broker-pod-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
   experiments:

--- a/charts/kube-aws/ebs-loss/engine.yaml
+++ b/charts/kube-aws/ebs-loss/engine.yaml
@@ -7,7 +7,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: ebs-loss-sa
-  monitoring: false
   # It can be retain/delete
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/kube-aws/ec2-terminate/engine.yaml
+++ b/charts/kube-aws/ec2-terminate/engine.yaml
@@ -7,7 +7,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: ec2-terminate-sa
-  monitoring: false
   # It can be retain/delete
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/kube-aws/k8-aws-ec2-terminate/engine.yaml
+++ b/charts/kube-aws/k8-aws-ec2-terminate/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   annotationCheck: 'false'
   engineState: 'active'
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   chaosServiceAccount: chaos-admin
   components:

--- a/charts/kube-components/k8-alb-ingress-controller/engine.yaml
+++ b/charts/kube-components/k8-alb-ingress-controller/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-calico-node/engine.yaml
+++ b/charts/kube-components/k8-calico-node/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-count.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-count.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: "app=kiam"
     appkind: deployment
   jobCleanUpPolicy: retain
-  monitoring: false
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-count.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-count.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: "app=kiam"
     appkind: deployment
   jobCleanUpPolicy: retain
-  monitoring: false
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-health.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-health.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: "app=kiam"
     appkind: deployment
   jobCleanUpPolicy: retain
-  monitoring: false
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-health.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-health.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: "app=kiam"
     appkind: deployment
   jobCleanUpPolicy: retain
-  monitoring: false
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin

--- a/charts/kube-components/k8-kiam/engine.yaml
+++ b/charts/kube-components/k8-kiam/engine.yaml
@@ -12,7 +12,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-kube-proxy/engine.yaml
+++ b/charts/kube-components/k8-kube-proxy/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-prometheus-k8s-prometheus/engine.yaml
+++ b/charts/kube-components/k8-prometheus-k8s-prometheus/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-prometheus-operator/engine.yaml
+++ b/charts/kube-components/k8-prometheus-operator/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-prometheus-pushgateway/engine.yaml
+++ b/charts/kube-components/k8-prometheus-pushgateway/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/kube-components/k8-wavefront-collector/engine.yaml
+++ b/charts/kube-components/k8-wavefront-collector/engine.yaml
@@ -11,7 +11,6 @@ spec:
   annotationCheck: 'false'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  monitoring: false
   jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete

--- a/charts/openebs/openebs-control-plane-chaos/engine.yaml
+++ b/charts/openebs/openebs-control-plane-chaos/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'name=maya-apiserver'
     appkind: 'deployment'
   chaosServiceAccount: control-plane-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-nfs-provisioner-kill/engine.yaml
+++ b/charts/openebs/openebs-nfs-provisioner-kill/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'app=minio'
     appkind: 'deployment'
   chaosServiceAccount: nfs-chaos-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-pool-container-failure/engine.yaml
+++ b/charts/openebs/openebs-pool-container-failure/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-container-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-pool-disk-loss/engine.yaml
+++ b/charts/openebs/openebs-pool-disk-loss/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-disk-loss-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-pool-network-delay/engine.yaml
+++ b/charts/openebs/openebs-pool-network-delay/engine.yaml
@@ -10,7 +10,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-network-delay-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-pool-network-loss/engine.yaml
+++ b/charts/openebs/openebs-pool-network-loss/engine.yaml
@@ -13,7 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-network-loss-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-pool-pod-failure/engine.yaml
+++ b/charts/openebs/openebs-pool-pod-failure/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-pod-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-target-container-failure/engine.yaml
+++ b/charts/openebs/openebs-target-container-failure/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-container-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-target-network-delay/engine.yaml
+++ b/charts/openebs/openebs-target-network-delay/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-network-delay-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-target-network-loss/engine.yaml
+++ b/charts/openebs/openebs-target-network-loss/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-network-loss-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/openebs-target-pod-failure/engine.yaml
+++ b/charts/openebs/openebs-target-pod-failure/engine.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-pod-failure-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/charts/openebs/sample_openebs_engine_with_data_persistency_enabled.yaml
+++ b/charts/openebs/sample_openebs_engine_with_data_persistency_enabled.yaml
@@ -15,7 +15,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: <experiments-name>-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/service-accounts/argowf-chaos-admin.yaml
+++ b/service-accounts/argowf-chaos-admin.yaml
@@ -43,7 +43,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: retain
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: litmus-admin

--- a/workflows/k8-calico-node/workflow.yaml
+++ b/workflows/k8-calico-node/workflow.yaml
@@ -71,7 +71,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
@@ -121,7 +120,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}

--- a/workflows/k8-kiam/workflow.yaml
+++ b/workflows/k8-kiam/workflow.yaml
@@ -71,7 +71,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
@@ -121,7 +120,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}

--- a/workflows/k8-pod-delete/workflow.yaml
+++ b/workflows/k8-pod-delete/workflow.yaml
@@ -94,7 +94,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'true'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
@@ -144,7 +143,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'true'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}

--- a/workflows/k8-service-kill/workflow.yaml
+++ b/workflows/k8-service-kill/workflow.yaml
@@ -71,7 +71,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
@@ -121,7 +120,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}

--- a/workflows/k8-wavefront-collector/workflow.yaml
+++ b/workflows/k8-wavefront-collector/workflow.yaml
@@ -71,7 +71,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
@@ -121,7 +120,6 @@ spec:
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
                 jobCleanUpPolicy: delete
-                monitoring: false
                 annotationCheck: 'false'
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}

--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -58,7 +58,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -94,7 +93,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -134,7 +132,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -174,7 +171,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -209,7 +205,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin

--- a/workflows/kube-proxy-all/workflow_cron.yaml
+++ b/workflows/kube-proxy-all/workflow_cron.yaml
@@ -61,7 +61,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -97,7 +96,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -137,7 +135,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -177,7 +174,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -212,7 +208,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin

--- a/workflows/namespaced-scope-chaos/workflow.yaml
+++ b/workflows/namespaced-scope-chaos/workflow.yaml
@@ -129,7 +129,6 @@ spec:
                     applabel: 'app=hello-world'
                     appkind: deployment
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-namespace-admin

--- a/workflows/namespaced-scope-chaos/workflow_cron.yaml
+++ b/workflows/namespaced-scope-chaos/workflow_cron.yaml
@@ -133,7 +133,6 @@ spec:
                       applabel: 'app=hello-world'
                       appkind: deployment
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-namespace-admin

--- a/workflows/node-cpu-hog/workflow.yaml
+++ b/workflows/node-cpu-hog/workflow.yaml
@@ -126,7 +126,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin

--- a/workflows/node-cpu-hog/workflow_cron.yaml
+++ b/workflows/node-cpu-hog/workflow_cron.yaml
@@ -130,7 +130,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin

--- a/workflows/node-memory-hog/workflow.yaml
+++ b/workflows/node-memory-hog/workflow.yaml
@@ -126,7 +126,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin

--- a/workflows/node-memory-hog/workflow_cron.yaml
+++ b/workflows/node-memory-hog/workflow_cron.yaml
@@ -122,7 +122,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin

--- a/workflows/pod-cpu-hog/workflow.yaml
+++ b/workflows/pod-cpu-hog/workflow.yaml
@@ -120,7 +120,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin

--- a/workflows/pod-cpu-hog/workflow_cron.yaml
+++ b/workflows/pod-cpu-hog/workflow_cron.yaml
@@ -124,7 +124,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin

--- a/workflows/pod-delete/workflow.yaml
+++ b/workflows/pod-delete/workflow.yaml
@@ -126,7 +126,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin

--- a/workflows/pod-delete/workflow_cron.yaml
+++ b/workflows/pod-delete/workflow_cron.yaml
@@ -130,7 +130,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin

--- a/workflows/pod-memory-hog/workflow.yaml
+++ b/workflows/pod-memory-hog/workflow.yaml
@@ -121,7 +121,6 @@ spec:
                     applabel: "k8s-app=kube-proxy"
                     appkind: daemonset
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin

--- a/workflows/pod-memory-hog/workflow_cron.yaml
+++ b/workflows/pod-memory-hog/workflow_cron.yaml
@@ -125,7 +125,6 @@ spec:
                       applabel: "k8s-app=kube-proxy"
                       appkind: daemonset
                     jobCleanUpPolicy: retain
-                    monitoring: false
                     annotationCheck: 'false'
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -378,14 +378,13 @@ spec:
                         - name: "check-catalogue-db-cr-status"
                           type: "k8sProbe"
                           k8sProbe/inputs:
-                            command:
-                              group: ""
-                              version: "v1"
-                              resource: "pods"
-                              namespace: "sock-shop"
-                              fieldSelector: "status.phase=Running"
-                              labelSelector: "name=catalogue-db"
-                          operation: "present"
+                            group: ""
+                            version: "v1"
+                            resource: "pods"
+                            namespace: "sock-shop"
+                            fieldSelector: "status.phase=Running"
+                            labelSelector: "name=catalogue-db"
+                            operation: "present"
                           mode: "Continuous"
                           runProperties:
                             probeTimeout: 1

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -70,7 +70,6 @@ spec:
                     applabel: 'name=carts'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -143,7 +142,6 @@ spec:
                     applabel: 'name=orders'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -216,7 +214,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: true
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:
@@ -289,7 +286,6 @@ spec:
                     applabel: 'name=user-db'
                     appkind: 'statefulset'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -368,7 +364,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: false
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -382,14 +382,13 @@ spec:
                         - name: "check-catalogue-db-cr-status"
                           type: "k8sProbe"
                           k8sProbe/inputs:
-                            command:
-                              group: ""
-                              version: "v1"
-                              resource: "pods"
-                              namespace: "sock-shop"
-                              fieldSelector: "status.phase=Running"
-                              labelSelector: "name=catalogue-db"
-                          operation: "present"
+                            group: ""
+                            version: "v1"
+                            resource: "pods"
+                            namespace: "sock-shop"
+                            fieldSelector: "status.phase=Running"
+                            labelSelector: "name=catalogue-db"
+                            operation: "present"
                           mode: "Continuous"
                           runProperties:
                             probeTimeout: 1

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -74,7 +74,6 @@ spec:
                     applabel: 'name=carts'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -147,7 +146,6 @@ spec:
                     applabel: 'name=orders'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -220,7 +218,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: true
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:
@@ -293,7 +290,6 @@ spec:
                     applabel: 'name=user-db'
                     appkind: 'statefulset'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -372,7 +368,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: false
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -372,14 +372,13 @@ spec:
                         - name: "check-catalogue-db-cr-status"
                           type: "k8sProbe"
                           k8sProbe/inputs:
-                            command:
-                              group: ""
-                              version: "v1"
-                              resource: "pods"
-                              namespace: "sock-shop"
-                              fieldSelector: "status.phase=Running"
-                              labelSelector: "name=catalogue-db"
-                          operation: "present"
+                            group: ""
+                            version: "v1"
+                            resource: "pods"
+                            namespace: "sock-shop"
+                            fieldSelector: "status.phase=Running"
+                            labelSelector: "name=catalogue-db"
+                            operation: "present"
                           mode: "Continuous"
                           runProperties:
                             probeTimeout: 1

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -70,7 +70,6 @@ spec:
                     applabel: 'name=carts'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -141,7 +140,6 @@ spec:
                     applabel: 'name=orders'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -212,7 +210,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: true
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:
@@ -283,7 +280,6 @@ spec:
                     applabel: 'name=user-db'
                     appkind: 'statefulset'
                   jobCleanUpPolicy: retain
-                  monitoring: true
                   annotationCheck: 'false'
                   engineState: 'active'
                   auxiliaryAppInfo: ''
@@ -361,7 +357,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: false
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -377,14 +377,13 @@ spec:
                         - name: "check-catalogue-db-cr-status"
                           type: "k8sProbe"
                           k8sProbe/inputs:
-                            command:
-                              group: ""
-                              version: "v1"
-                              resource: "pods"
-                              namespace: "sock-shop"
-                              fieldSelector: "status.phase=Running"
-                              labelSelector: "name=catalogue-db"
-                          operation: "present"
+                            group: ""
+                            version: "v1"
+                            resource: "pods"
+                            namespace: "sock-shop"
+                            fieldSelector: "status.phase=Running"
+                            labelSelector: "name=catalogue-db"
+                            operation: "present"
                           mode: "Continuous"
                           runProperties:
                             probeTimeout: 1

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -76,7 +76,6 @@ spec:
                     applabel: 'name=carts'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -147,7 +146,6 @@ spec:
                     applabel: 'name=orders'
                     appkind: 'deployment'
                   jobCleanUpPolicy: retain
-                  monitoring: false
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -218,7 +216,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: true
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:
@@ -289,7 +286,6 @@ spec:
                     applabel: 'name=user-db'
                     appkind: 'statefulset'
                   jobCleanUpPolicy: retain
-                  monitoring: true
                   annotationCheck: 'false'
                   engineState: 'active'
                   auxiliaryAppInfo: ''
@@ -367,7 +363,6 @@ spec:
                   annotationCheck: 'false'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
-                  monitoring: false
                   jobCleanUpPolicy: 'retain'
                   components:
                     runner:


### PR DESCRIPTION
- Removed monitoring attribute from all the experiments as monitoring is independent of monitoring flag. Monitoring can be enabled by chaos-exporter installation and can b disabled by skipping chaos-exporter installation.
- Removing `appinfo` from the infra/node experiments as The AUT status check is optional for infra experiments