### PR TITLE
chore(pre-define workflow): Added podtato-head workflow 

### DIFF
--- a/workflows/podtato-head/workflow.yaml
+++ b/workflows/podtato-head/workflow.yaml
@@ -1,0 +1,114 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: argowf-podtato-head-chaos-
+  namespace: litmus
+spec:
+  entrypoint: argowf-chaos
+  serviceAccountName: argo-chaos
+  securityContext:
+    runAsUser: 1000
+    runAsNonRoot: true
+  arguments:
+    parameters:
+      - name: adminModeNamespace
+        value: "litmus"
+  templates:
+    - name: argowf-chaos
+      steps:
+        - - name: install-application
+            template: install-application
+        - - name: install-chaos-experiments
+            template: install-chaos-experiments
+        - - name: pod-delete
+            template: pod-delete
+        - - name: revert-chaos
+            template: revert-chaos
+          - name: delete-application
+            template: delete-application
+
+    - name: install-application
+      container:
+        image: litmuschaos/litmus-app-deployer:latest
+        args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=apply","-timeout=400", "-app=podtato-head"]
+
+    - name: install-chaos-experiments
+      container:
+        image: alpine/k8s:1.18.2
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+
+    - name: pod-delete
+      inputs:
+        artifacts:
+          - name: pod-delete
+            path: /tmp/chaosengine.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: podtato-head-pod-delete-chaos
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                  labels:
+                    litmuschaos.io/engine-context: lab
+                spec:
+                  appinfo:
+                    appns: {{workflow.parameters.adminModeNamespace}}
+                    applabel: 'app in (podtato-head)'
+                    appkind: 'deployment'
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  jobCleanUpPolicy: 'retain'
+                  components:
+                    runner:
+                      imagePullPolicy: Always
+                  experiments:
+                    - name: pod-delete
+                      spec:
+                        probe:
+                        - name: "check-podtato-head-access-url"
+                          type: "httpProbe"
+                          httpProbe/inputs:
+                            url: "http://podtato.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
+                            insecureSkipVerify: false
+                            responseTimeout: 100
+                            method:
+                              get:
+                                criteria: "=="
+                                responseCode: "200"
+                          mode: "Continuous"
+                          runProperties:
+                            probeTimeout: 1
+                            interval: 1
+                            retry: 1
+                        components:
+                          env:
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '30'
+                            # set chaos interval (in sec) as desired
+                            - name: CHAOS_INTERVAL
+                              value: '10'
+                            # pod failures without '--force' & default terminationGracePeriodSeconds
+                            - name: FORCE
+                              value: 'false'
+      container:
+        image: litmuschaos/litmus-checker:latest
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]        
+
+    - name: delete-application
+      container:
+        image: litmuschaos/litmus-app-deployer:latest
+        args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=delete","-app=podtato-head"]
+    
+    - name: revert-chaos
+      container:
+        image: alpine/k8s:1.18.2
+        command: [sh, -c]
+        args: 
+          [ 
+            "kubectl delete chaosengine podtato-head-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
+          ]

--- a/workflows/podtato-head/workflow.yaml
+++ b/workflows/podtato-head/workflow.yaml
@@ -52,12 +52,10 @@ spec:
                 metadata:
                   name: podtato-head-pod-delete-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
-                  labels:
-                    litmuschaos.io/engine-context: lab
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}
-                    applabel: 'app in (podtato-head)'
+                    applabel: 'app=podtato-head'
                     appkind: 'deployment'
                   annotationCheck: 'false'
                   engineState: 'active'
@@ -75,7 +73,6 @@ spec:
                           httpProbe/inputs:
                             url: "http://podtato.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
                             insecureSkipVerify: false
-                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="

--- a/workflows/podtato-head/workflow_cron.yaml
+++ b/workflows/podtato-head/workflow_cron.yaml
@@ -56,12 +56,10 @@ spec:
                 metadata:
                   name: podtato-head-pod-delete-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
-                  labels:
-                    litmuschaos.io/engine-context: lab
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}
-                    applabel: 'app in (podtato-head)'
+                    applabel: 'app=podtato-head'
                     appkind: 'deployment'
                   annotationCheck: 'false'
                   engineState: 'active'
@@ -79,7 +77,6 @@ spec:
                           httpProbe/inputs:
                             url: "http://podtato.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
                             insecureSkipVerify: false
-                            responseTimeout: 100
                             method:
                               get:
                                 criteria: "=="

--- a/workflows/podtato-head/workflow_cron.yaml
+++ b/workflows/podtato-head/workflow_cron.yaml
@@ -1,0 +1,118 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: argowf-podtato-head-chaos-cron-wf
+  namespace: litmus
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  workflowSpec:
+    entrypoint: argowf-chaos
+    serviceAccountName: argo-chaos
+    securityContext:
+      runAsUser: 1000
+      runAsNonRoot: true
+    arguments:
+      parameters:
+        - name: adminModeNamespace
+          value: "litmus"
+    templates:
+    - name: argowf-chaos
+      steps:
+      - - name: install-application
+          template: install-application
+      - - name: install-chaos-experiments
+          template: install-chaos-experiments
+      - - name: pod-delete
+          template: pod-delete
+      - - name: revert-chaos
+          template: revert-chaos
+        - name: delete-application
+          template: delete-application
+
+    - name: install-application
+      container:
+        image: litmuschaos/litmus-app-deployer:latest
+        args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=apply","-timeout=400", "-app=podtato-head"]
+
+    - name: install-chaos-experiments
+      container:
+        image: alpine/k8s:1.18.2
+        command: [sh, -c]
+        args:
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+
+    - name: pod-delete
+      inputs:
+        artifacts:
+          - name: pod-delete
+            path: /tmp/chaosengine.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: podtato-head-pod-delete-chaos
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                  labels:
+                    litmuschaos.io/engine-context: lab
+                spec:
+                  appinfo:
+                    appns: {{workflow.parameters.adminModeNamespace}}
+                    applabel: 'app in (podtato-head)'
+                    appkind: 'deployment'
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  jobCleanUpPolicy: 'retain'
+                  components:
+                    runner:
+                      imagePullPolicy: Always
+                  experiments:
+                    - name: pod-delete
+                      spec:
+                        probe:
+                        - name: "check-podtato-head-access-url"
+                          type: "httpProbe"
+                          httpProbe/inputs:
+                            url: "http://podtato.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
+                            insecureSkipVerify: false
+                            responseTimeout: 100
+                            method:
+                              get:
+                                criteria: "=="
+                                responseCode: "200"
+                          mode: "Continuous"
+                          runProperties:
+                            probeTimeout: 1
+                            interval: 1
+                            retry: 1
+                        components:
+                          env:
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '30'
+                            # set chaos interval (in sec) as desired
+                            - name: CHAOS_INTERVAL
+                              value: '10'
+                            # pod failures without '--force' & default terminationGracePeriodSeconds
+                            - name: FORCE
+                              value: 'false'
+      container:
+        image: litmuschaos/litmus-checker:latest
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]        
+
+    - name: delete-application
+      container:
+        image: litmuschaos/litmus-app-deployer:latest
+        args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=delete","-app=podtato-head"]
+    
+    - name: revert-chaos
+      container:
+        image: alpine/k8s:1.18.2
+        command: [sh, -c]
+        args: 
+          [ 
+            "kubectl delete chaosengine podtato-head-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
+          ]


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

This PR is adding new predined workflow podtato-head. 
 - Having two scenarios weak and resilient.
 - Used probe httpProbe

Template Card :

![Screenshot from 2021-04-12 11-49-22](https://user-images.githubusercontent.com/34105373/114349210-3b226e80-9b85-11eb-8050-4f8b2908699d.png)

 Workflow Representation:
  
![3](https://user-images.githubusercontent.com/34105373/114375931-cd853b00-9ba2-11eb-8424-c3e278c4a5fa.png)

![4](https://user-images.githubusercontent.com/34105373/114374103-eab90a00-9ba0-11eb-808f-782d4c9582fd.png)
![5](https://user-images.githubusercontent.com/34105373/114374112-ed1b6400-9ba0-11eb-8679-1ee581832196.png)
![6](https://user-images.githubusercontent.com/34105373/114374122-eee52780-9ba0-11eb-8dc5-814bbfc819ba.png)
![7](https://user-images.githubusercontent.com/34105373/114374128-f0165480-9ba0-11eb-9f4c-f151e2c15729.png)
![8](https://user-images.githubusercontent.com/34105373/114374132-f1478180-9ba0-11eb-9889-6b990af490db.png)
![9](https://user-images.githubusercontent.com/34105373/114374137-f1e01800-9ba0-11eb-8290-304c1e5f3b14.png)
![10](https://user-images.githubusercontent.com/34105373/114374143-f3114500-9ba0-11eb-9022-21cf21616cc3.png)
![11](https://user-images.githubusercontent.com/34105373/114374148-f3a9db80-9ba0-11eb-9bc2-dd7eebc3d479.png)


![Screenshot from 2021-04-07 17-54-11](https://user-images.githubusercontent.com/34105373/113867778-92fb5700-97cc-11eb-80ca-8331b31082b8.png)

Schedule a Workflow :
![1](https://user-images.githubusercontent.com/34105373/114374083-e55bbf80-9ba0-11eb-952f-70a0f5522a58.png)


```ChaosResult ```  :+1: 

![Screenshot from 2021-04-08 16-18-07](https://user-images.githubusercontent.com/34105373/114014614-6c015b80-9886-11eb-9338-6a2b8113fba8.png)
