### PR TITLE
Appinfo removed from engines for infra level experiments

### DIFF
--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -53,10 +53,6 @@ spec:
                   name: kube-proxy-node-cpu-hog
                   namespace: {{workflow.parameters.adminModeNamespace}}
                 spec:
-                  appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
                   jobCleanUpPolicy: retain
                   annotationCheck: 'false'
                   engineState: 'active'
@@ -166,10 +162,6 @@ spec:
                   name: kube-proxy-node-memory-hog-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
                 spec:
-                  appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
                   jobCleanUpPolicy: retain
                   annotationCheck: 'false'
                   engineState: 'active'

--- a/workflows/kube-proxy-all/workflow_cron.yaml
+++ b/workflows/kube-proxy-all/workflow_cron.yaml
@@ -56,10 +56,6 @@ spec:
                     name: kube-proxy-node-cpu-hog
                     namespace: {{workflow.parameters.adminModeNamespace}}
                   spec:
-                    appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
                     jobCleanUpPolicy: retain
                     annotationCheck: 'false'
                     engineState: 'active'
@@ -169,10 +165,6 @@ spec:
                     name: kube-proxy-node-memory-hog-chaos
                     namespace: {{workflow.parameters.adminModeNamespace}}
                   spec:
-                    appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
                     jobCleanUpPolicy: retain
                     annotationCheck: 'false'
                     engineState: 'active'

--- a/workflows/node-cpu-hog/workflow.yaml
+++ b/workflows/node-cpu-hog/workflow.yaml
@@ -121,10 +121,6 @@ spec:
                   name: kube-proxy-node-cpu-hog-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
                 spec:
-                  appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
                   jobCleanUpPolicy: retain
                   annotationCheck: 'false'
                   engineState: 'active'

--- a/workflows/node-cpu-hog/workflow_cron.yaml
+++ b/workflows/node-cpu-hog/workflow_cron.yaml
@@ -125,10 +125,6 @@ spec:
                     name: kube-proxy-node-cpu-hog-chaos
                     namespace: {{workflow.parameters.adminModeNamespace}}
                   spec:
-                    appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
                     jobCleanUpPolicy: retain
                     annotationCheck: 'false'
                     engineState: 'active'

--- a/workflows/node-memory-hog/workflow.yaml
+++ b/workflows/node-memory-hog/workflow.yaml
@@ -121,10 +121,6 @@ spec:
                   name: kube-proxy-node-memory-hog-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
                 spec:
-                  appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
                   jobCleanUpPolicy: retain
                   annotationCheck: 'false'
                   engineState: 'active'

--- a/workflows/node-memory-hog/workflow_cron.yaml
+++ b/workflows/node-memory-hog/workflow_cron.yaml
@@ -117,10 +117,6 @@ spec:
                     name: kube-proxy-node-memory-hog-chaos
                     namespace: {{workflow.parameters.adminModeNamespace}}
                   spec:
-                    appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
                     jobCleanUpPolicy: retain
                     annotationCheck: 'false'
                     engineState: 'active'


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

This PR will remove ```appinfo``` for infra level experiments from chaos engine. 
  
Changed Engines :  
   - node-memory-hog
   - node-cpu-hog