### PR TITLE
(chore)env: add stress image env to pod resource exp

### DIFF
--- a/charts/generic/pod-cpu-hog/experiment.yaml
+++ b/charts/generic/pod-cpu-hog/experiment.yaml
@@ -77,6 +77,10 @@ spec:
     - name: LIB_IMAGE
       value: 'litmuschaos/go-runner:latest'  
 
+    ## It is used in pumba lib only    
+    - name: STRESS_IMAGE
+      value: 'alexeiled/stress-ng:latest-ubuntu'  
+
     # provide the socket file path
     # it is used in pumba lib
     - name: SOCKET_PATH

--- a/charts/generic/pod-memory-hog/experiment.yaml
+++ b/charts/generic/pod-memory-hog/experiment.yaml
@@ -78,6 +78,10 @@ spec:
       - name: LIB_IMAGE
         value: 'litmuschaos/go-runner:latest'
 
+      ## It is used in pumba lib only    
+      - name: STRESS_IMAGE
+        value: 'alexeiled/stress-ng:latest-ubuntu'
+
       # provide the socket file path
       # it is used in pumba lib
       - name: SOCKET_PATH


### PR DESCRIPTION
- Adds an additional environment variable "STRESS_IMAGE" for use in pumba lib - with default pointing to `alexeiled/stress-ng:latest-ubuntu`
- This will help users of pumba lib running with private image registries to define their own version of the stress-image.

Signed-off-by: ksatchit <karthik.s@mayadata.io>