### PR TITLE
chore(version): updating the image version in workflows

### DIFF
--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -37,7 +37,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.13.2?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.13.3?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} | sleep 30"
 
     - name: node-cpu-hog
@@ -96,7 +96,6 @@ spec:
                     - name: pod-memory-hog
                       spec:
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TARGET_CONTAINER
                               value: 'kube-proxy'
@@ -135,7 +134,6 @@ spec:
                     - name: pod-cpu-hog
                       spec:
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TARGET_CONTAINER
                               value: 'kube-proxy'

--- a/workflows/kube-proxy-all/workflow_cron.yaml
+++ b/workflows/kube-proxy-all/workflow_cron.yaml
@@ -40,7 +40,7 @@ spec:
           image: litmuschaos/k8s:latest
           command: [sh, -c]
           args:
-            - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.13.2?file=charts/generic/experiments.yaml -n
+            - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.13.3?file=charts/generic/experiments.yaml -n
               {{workflow.parameters.adminModeNamespace}} | sleep 30"
 
       - name: node-cpu-hog
@@ -99,7 +99,6 @@ spec:
                       - name: pod-memory-hog
                         spec:
                           components:
-                            experimentImage: "litmuschaos/go-runner:1.13.3"
                             env:
                               - name: TARGET_CONTAINER
                                 value: 'kube-proxy'
@@ -138,7 +137,6 @@ spec:
                       - name: pod-cpu-hog
                         spec:
                           components:
-                            experimentImage: "litmuschaos/go-runner:1.13.3"
                             env:
                               - name: TARGET_CONTAINER
                                 value: 'kube-proxy'

--- a/workflows/pod-cpu-hog/workflow.yaml
+++ b/workflows/pod-cpu-hog/workflow.yaml
@@ -127,7 +127,6 @@ spec:
                     - name: pod-cpu-hog
                       spec:
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TARGET_CONTAINER
                               value: 'kube-proxy'

--- a/workflows/pod-cpu-hog/workflow_cron.yaml
+++ b/workflows/pod-cpu-hog/workflow_cron.yaml
@@ -131,7 +131,6 @@ spec:
                       - name: pod-cpu-hog
                         spec:
                           components:
-                            experimentImage: "litmuschaos/go-runner:1.13.3"
                             env:
                               - name: TARGET_CONTAINER
                                 value: 'kube-proxy'

--- a/workflows/pod-memory-hog/workflow.yaml
+++ b/workflows/pod-memory-hog/workflow.yaml
@@ -128,7 +128,6 @@ spec:
                     - name: pod-memory-hog
                       spec:
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TARGET_CONTAINER
                               value: 'kube-proxy'

--- a/workflows/pod-memory-hog/workflow_cron.yaml
+++ b/workflows/pod-memory-hog/workflow_cron.yaml
@@ -132,7 +132,6 @@ spec:
                       - name: pod-memory-hog
                         spec:
                           components:
-                            experimentImage: "litmuschaos/go-runner:1.13.3"
                             env:
                               - name: TARGET_CONTAINER
                                 value: 'kube-proxy'

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -109,7 +109,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -181,7 +180,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -254,7 +252,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -328,7 +325,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -404,7 +400,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 1
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -113,7 +113,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -185,7 +184,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 10
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -258,7 +256,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -332,7 +329,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -408,7 +404,6 @@ spec:
                             retry: 2
                             initialDelaySeconds: 1
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -107,7 +107,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -177,7 +176,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -248,7 +246,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -321,7 +318,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -395,7 +391,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -113,7 +113,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             #number of cpu cores to be consumed
                             #verify the resources the app has been launched with
@@ -183,7 +182,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -254,7 +252,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30'
@@ -327,7 +324,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: TOTAL_CHAOS_DURATION
                               value: '30' 
@@ -401,7 +397,6 @@ spec:
                             interval: 1
                             retry: 2
                         components:
-                          experimentImage: "litmuschaos/go-runner:1.13.3"
                           env:
                             - name: FILL_PERCENTAGE
                               value: '100'


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

-  updating the go-runner image version to 1.13.3
-  updating the hub link to 1.13.3 version
-  removed the experimentImage override from the chaosengine