### PR TITLE
Updating podtato-head predefined workflow

### DIFF
--- a/workflows/podtato-head/workflow.yaml
+++ b/workflows/podtato-head/workflow.yaml
@@ -28,7 +28,7 @@ spec:
             template: revert-chaos
           - name: delete-application
             template: delete-application
-        
+
     - name: install-application
       container:
         image: litmuschaos/litmus-app-deployer:latest

--- a/workflows/podtato-head/workflow.yaml
+++ b/workflows/podtato-head/workflow.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: argowf-podtato-head-chaos-
   namespace: litmus
   labels:
-    subject : "{{workflow.parameters.adminModeNamespace}}_podtato-head"
+    subject : "{{workflow.parameters.adminModeNamespace}}_podtato-main"
 spec:
   entrypoint: argowf-chaos
   serviceAccountName: argo-chaos
@@ -28,7 +28,7 @@ spec:
             template: revert-chaos
           - name: delete-application
             template: delete-application
-
+        
     - name: install-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
@@ -52,14 +52,14 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: podtato-head-pod-delete-chaos
+                  name: podtato-main-pod-delete-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
-                    context: "{{workflow.parameters.adminModeNamespace}}_podtato-head"
+                    context: "{{workflow.parameters.adminModeNamespace}}_podtato-main"
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}
-                    applabel: 'app=podtato-head'
+                    applabel: 'name=podtato-main'
                     appkind: 'deployment'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -71,10 +71,10 @@ spec:
                     - name: pod-delete
                       spec:
                         probe:
-                        - name: "check-podtato-head-access-url"
+                        - name: "check-podtato-main-access-url"
                           type: "httpProbe"
                           httpProbe/inputs:
-                            url: "http://podtato.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
+                            url: "http://podtato-main.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
                             insecureSkipVerify: false
                             method:
                               get:
@@ -110,5 +110,5 @@ spec:
         command: [sh, -c]
         args: 
           [ 
-            "kubectl delete chaosengine podtato-head-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine podtato-main-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/workflows/podtato-head/workflow_cron.yaml
+++ b/workflows/podtato-head/workflow_cron.yaml
@@ -56,14 +56,14 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: podtato-head-pod-delete-chaos
+                  name: podtato-main-pod-delete-chaos
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
-                    context: "{{workflow.parameters.adminModeNamespace}}_podtato-head"
+                    context: "{{workflow.parameters.adminModeNamespace}}_podtato-main"
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}
-                    applabel: 'app=podtato-head'
+                    applabel: 'name=podtato-main'
                     appkind: 'deployment'
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -75,10 +75,10 @@ spec:
                     - name: pod-delete
                       spec:
                         probe:
-                        - name: "check-podtato-head-access-url"
+                        - name: "check-podtato-main-access-url"
                           type: "httpProbe"
                           httpProbe/inputs:
-                            url: "http://podtato.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
+                            url: "http://podtato-main.{{workflow.parameters.adminModeNamespace}}.svc.cluster.local:9000"
                             insecureSkipVerify: false
                             method:
                               get:
@@ -114,5 +114,5 @@ spec:
         command: [sh, -c]
         args: 
           [ 
-            "kubectl delete chaosengine podtato-head-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine podtato-main-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

This PR is adding new experiment pod-dns-scoof for podtato-head predefined workflow.
 Where spoofing from an ```podtato-hats-new``` source as being from a ```podtato-hats```
 