### PR TITLE
chore(jobCleanUpPolicy): added retain as default jobCleanUpPolicy

### DIFF
--- a/charts/azure/azure-instance-terminate/engine.yaml
+++ b/charts/azure/azure-instance-terminate/engine.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   engineState: 'active'
   chaosServiceAccount: azure-instance-terminate-sa
+  monitoring: false
+  # It can be retain/delete
+  jobCleanUpPolicy: 'delete'
   experiments:
     - name: azure-instance-terminate
       spec:

--- a/charts/azure/azure-instance-terminate/engine.yaml
+++ b/charts/azure/azure-instance-terminate/engine.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   engineState: 'active'
   chaosServiceAccount: azure-instance-terminate-sa
-  monitoring: false
-  # It can be retain/delete
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: azure-instance-terminate
       spec:

--- a/charts/cassandra/cassandra-pod-delete/ansible/engine.yaml
+++ b/charts/cassandra/cassandra-pod-delete/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: cassandra-pod-delete-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: cassandra-pod-delete
       spec:

--- a/charts/cassandra/cassandra-pod-delete/engine.yaml
+++ b/charts/cassandra/cassandra-pod-delete/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: cassandra-pod-delete-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: cassandra-pod-delete
       spec:

--- a/charts/coredns/coredns-pod-delete/engine.yaml
+++ b/charts/coredns/coredns-pod-delete/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: coredns-pod-delete-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: coredns-pod-delete
       spec:

--- a/charts/generic/container-kill/ansible/engine.yaml
+++ b/charts/generic/container-kill/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: container-kill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete' 
   experiments:
     - name: container-kill
       spec:

--- a/charts/generic/container-kill/engine.yaml
+++ b/charts/generic/container-kill/engine.yaml
@@ -11,8 +11,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: container-kill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete' 
   experiments:
     - name: container-kill
       spec:

--- a/charts/generic/disk-fill/ansible/engine.yaml
+++ b/charts/generic/disk-fill/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: disk-fill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: disk-fill
       spec:

--- a/charts/generic/disk-fill/engine.yaml
+++ b/charts/generic/disk-fill/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: disk-fill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: disk-fill
       spec:

--- a/charts/generic/disk-loss/engine.yaml
+++ b/charts/generic/disk-loss/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: disk-loss-sa
-  # It can be retain/delete
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: disk-loss
       spec:

--- a/charts/generic/docker-service-kill/engine.yaml
+++ b/charts/generic/docker-service-kill/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: docker-service-kill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: docker-service-kill
       spec:

--- a/charts/generic/k8-pod-delete/Cluster/engine-app-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-app-all-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Cluster/engine-app-count.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-app-count.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Cluster/engine-app-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-app-health.yaml
@@ -9,8 +9,7 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   engineState: 'active'
-  chaosServiceAccount: chaos-admin 
-  jobCleanUpPolicy: 'retain'
+  chaosServiceAccount: chaos-admin
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Cluster/engine-custom-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-custom-all-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Cluster/engine-custom-count.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-custom-count.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Cluster/engine-custom-health.yaml
+++ b/charts/generic/k8-pod-delete/Cluster/engine-custom-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Service/engine-app-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-app-all-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Service/engine-app-count.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-app-count.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Service/engine-app-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-app-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Service/engine-custom-all-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-custom-all-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Service/engine-custom-count.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-custom-count.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/Service/engine-custom-health.yaml
+++ b/charts/generic/k8-pod-delete/Service/engine-custom-health.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-pod-delete/engine.yaml
+++ b/charts/generic/k8-pod-delete/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: k8-pod-delete-sa
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/generic/k8-service-kill/engine.yaml
+++ b/charts/generic/k8-service-kill/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: 'deployment'
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-service-kill
       spec:

--- a/charts/generic/kubelet-service-kill/ansible/engine.yaml
+++ b/charts/generic/kubelet-service-kill/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: kubelet-service-kill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: kubelet-service-kill
       spec:

--- a/charts/generic/kubelet-service-kill/engine.yaml
+++ b/charts/generic/kubelet-service-kill/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: kubelet-service-kill-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: kubelet-service-kill
       spec:

--- a/charts/generic/node-cpu-hog/ansible/engine.yaml
+++ b/charts/generic/node-cpu-hog/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: node-cpu-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-cpu-hog
       spec:

--- a/charts/generic/node-cpu-hog/engine.yaml
+++ b/charts/generic/node-cpu-hog/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-cpu-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-cpu-hog
       spec:

--- a/charts/generic/node-drain/ansible/engine.yaml
+++ b/charts/generic/node-drain/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: node-drain-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-drain
       spec:

--- a/charts/generic/node-drain/engine.yaml
+++ b/charts/generic/node-drain/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-drain-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-drain
       spec:

--- a/charts/generic/node-io-stress/engine.yaml
+++ b/charts/generic/node-io-stress/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-io-stress-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-io-stress
       spec:

--- a/charts/generic/node-memory-hog/ansible/engine.yaml
+++ b/charts/generic/node-memory-hog/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: node-memory-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-memory-hog
       spec:

--- a/charts/generic/node-memory-hog/engine.yaml
+++ b/charts/generic/node-memory-hog/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-memory-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-memory-hog
       spec:

--- a/charts/generic/node-poweroff/engine.yaml
+++ b/charts/generic/node-poweroff/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-poweroff-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-poweroff
       spec:

--- a/charts/generic/node-restart/engine.yaml
+++ b/charts/generic/node-restart/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-restart-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-restart
       spec:

--- a/charts/generic/node-taint/engine.yaml
+++ b/charts/generic/node-taint/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   chaosServiceAccount: node-taint-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: node-taint
       spec:

--- a/charts/generic/pod-autoscaler/engine.yaml
+++ b/charts/generic/pod-autoscaler/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-autoscaler-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-autoscaler
       spec:

--- a/charts/generic/pod-cpu-hog/ansible/engine.yaml
+++ b/charts/generic/pod-cpu-hog/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-cpu-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-cpu-hog
       spec:

--- a/charts/generic/pod-cpu-hog/engine.yaml
+++ b/charts/generic/pod-cpu-hog/engine.yaml
@@ -12,8 +12,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-cpu-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-cpu-hog
       spec:

--- a/charts/generic/pod-delete/ansible/engine.yaml
+++ b/charts/generic/pod-delete/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: pod-delete-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-delete
       spec:

--- a/charts/generic/pod-delete/engine.yaml
+++ b/charts/generic/pod-delete/engine.yaml
@@ -11,8 +11,6 @@ spec:
   # It can be active/stop
   engineState: 'active'
   chaosServiceAccount: pod-delete-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-delete
       spec:

--- a/charts/generic/pod-dns-error/engine.yaml
+++ b/charts/generic/pod-dns-error/engine.yaml
@@ -9,7 +9,6 @@ spec:
     appkind: "deployment"
   # It can be active/stop
   engineState: "active"
-  annotationCheck: 'false'
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ""
   chaosServiceAccount: pod-dns-error-sa

--- a/charts/generic/pod-dns-error/engine.yaml
+++ b/charts/generic/pod-dns-error/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ""
   chaosServiceAccount: pod-dns-error-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: "delete"
   experiments:
     - name: pod-dns-error
       spec:

--- a/charts/generic/pod-dns-spoof/engine.yaml
+++ b/charts/generic/pod-dns-spoof/engine.yaml
@@ -9,7 +9,6 @@ spec:
     appkind: "deployment"
   # It can be active/stop
   engineState: "active"
-  annotationCheck: 'false'
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ""
   chaosServiceAccount: pod-dns-spoof-sa

--- a/charts/generic/pod-dns-spoof/engine.yaml
+++ b/charts/generic/pod-dns-spoof/engine.yaml
@@ -13,8 +13,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ""
   chaosServiceAccount: pod-dns-spoof-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: "delete"
   experiments:
     - name: pod-dns-spoof
       spec:

--- a/charts/generic/pod-io-stress/engine.yaml
+++ b/charts/generic/pod-io-stress/engine.yaml
@@ -11,8 +11,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-io-stress-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-io-stress
       spec:

--- a/charts/generic/pod-memory-hog/ansible/engine.yaml
+++ b/charts/generic/pod-memory-hog/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-memory-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-memory-hog
       spec:

--- a/charts/generic/pod-memory-hog/engine.yaml
+++ b/charts/generic/pod-memory-hog/engine.yaml
@@ -11,8 +11,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pod-memory-hog-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-memory-hog
       spec:

--- a/charts/generic/pod-network-corruption/ansible/engine.yaml
+++ b/charts/generic/pod-network-corruption/ansible/engine.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec:
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 

--- a/charts/generic/pod-network-corruption/engine.yaml
+++ b/charts/generic/pod-network-corruption/engine.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec:
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   appinfo: 

--- a/charts/generic/pod-network-duplication/engine.yaml
+++ b/charts/generic/pod-network-duplication/engine.yaml
@@ -5,8 +5,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec:
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   appinfo: 

--- a/charts/generic/pod-network-latency/ansible/engine.yaml
+++ b/charts/generic/pod-network-latency/ansible/engine.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec: 
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 

--- a/charts/generic/pod-network-latency/engine.yaml
+++ b/charts/generic/pod-network-latency/engine.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec: 
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   appinfo: 

--- a/charts/generic/pod-network-loss/ansible/engine.yaml
+++ b/charts/generic/pod-network-loss/ansible/engine.yaml
@@ -5,8 +5,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec:
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx 

--- a/charts/generic/pod-network-loss/engine.yaml
+++ b/charts/generic/pod-network-loss/engine.yaml
@@ -5,8 +5,6 @@ metadata:
   name: nginx-network-chaos
   namespace: default
 spec:
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   # It can be active/stop
   engineState: 'active'
   appinfo: 

--- a/charts/kafka/kafka-broker-disk-failure/engine.yaml
+++ b/charts/kafka/kafka-broker-disk-failure/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=cp-kafka'
     appkind: 'statefulset'
   chaosServiceAccount: kafka-broker-disk-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete' 
   experiments:
     - name: kafka-broker-disk-failure
       spec:

--- a/charts/kafka/kafka-broker-pod-failure/ansible/engine.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/ansible/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=cp-kafka'
     appkind: 'statefulset'
   chaosServiceAccount: kafka-broker-pod-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete' 
   experiments:
     - name: kafka-broker-pod-failure
       spec:

--- a/charts/kafka/kafka-broker-pod-failure/engine.yaml
+++ b/charts/kafka/kafka-broker-pod-failure/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=cp-kafka'
     appkind: 'statefulset'
   chaosServiceAccount: kafka-broker-pod-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete' 
   experiments:
     - name: kafka-broker-pod-failure
       spec:

--- a/charts/kube-aws/ebs-loss-by-id/engine.yaml
+++ b/charts/kube-aws/ebs-loss-by-id/engine.yaml
@@ -7,8 +7,6 @@ spec:
   engineState: 'active'
   annotationCheck: 'false'
   chaosServiceAccount: ebs-loss-by-id-sa
-  # It can be retain/delete
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: ebs-loss-by-id
       spec:

--- a/charts/kube-aws/ebs-loss-by-id/engine.yaml
+++ b/charts/kube-aws/ebs-loss-by-id/engine.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   engineState: 'active'
-  annotationCheck: 'false'
   chaosServiceAccount: ebs-loss-by-id-sa
   experiments:
     - name: ebs-loss-by-id

--- a/charts/kube-aws/ebs-loss-by-tag/engine.yaml
+++ b/charts/kube-aws/ebs-loss-by-tag/engine.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   engineState: 'active'
-  annotationCheck: 'false'
   chaosServiceAccount: ebs-loss-by-tag-sa
   experiments:
     - name: ebs-loss-by-tag

--- a/charts/kube-aws/ebs-loss-by-tag/engine.yaml
+++ b/charts/kube-aws/ebs-loss-by-tag/engine.yaml
@@ -7,8 +7,6 @@ spec:
   engineState: 'active'
   annotationCheck: 'false'
   chaosServiceAccount: ebs-loss-by-tag-sa
-  # It can be retain/delete
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: ebs-loss-by-tag
       spec:

--- a/charts/kube-aws/ec2-terminate-by-id/engine.yaml
+++ b/charts/kube-aws/ec2-terminate-by-id/engine.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   engineState: 'active'
   chaosServiceAccount: ec2-terminate-by-id-sa
-  # It can be retain/delete
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: ec2-terminate-by-id
       spec:

--- a/charts/kube-aws/ec2-terminate-by-tag/engine.yaml
+++ b/charts/kube-aws/ec2-terminate-by-tag/engine.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   engineState: 'active'
   chaosServiceAccount: ec2-terminate-by-tag-sa
-  # It can be retain/delete
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: ec2-terminate-by-tag
       spec:

--- a/charts/kube-aws/k8-aws-ec2-terminate/engine.yaml
+++ b/charts/kube-aws/k8-aws-ec2-terminate/engine.yaml
@@ -9,7 +9,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   engineState: 'active'
-  jobCleanUpPolicy: 'retain'
   chaosServiceAccount: chaos-admin
   components:
     runner:

--- a/charts/kube-components/k8-alb-ingress-controller/engine.yaml
+++ b/charts/kube-components/k8-alb-ingress-controller/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-calico-node/engine.yaml
+++ b/charts/kube-components/k8-calico-node/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-count.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-count.yaml
@@ -12,7 +12,6 @@ spec:
     #applabel: "app=nginx"
     applabel: "app=kiam"
     appkind: deployment
-  jobCleanUpPolicy: retain
   engineState: 'active'
   chaosServiceAccount: chaos-admin
   experiments:

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-count.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-count.yaml
@@ -12,7 +12,6 @@ spec:
     #applabel: "app=nginx"
     applabel: "app=kiam"
     appkind: deployment
-  jobCleanUpPolicy: retain
   engineState: 'active'
   chaosServiceAccount: chaos-admin
   experiments:

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-health.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-custom-health.yaml
@@ -12,7 +12,6 @@ spec:
     #applabel: "app=nginx"
     applabel: "app=kiam"
     appkind: deployment
-  jobCleanUpPolicy: retain
   engineState: 'active'
   chaosServiceAccount: chaos-admin
   experiments:

--- a/charts/kube-components/k8-kiam/Cluster/engine-kiam-health.yaml
+++ b/charts/kube-components/k8-kiam/Cluster/engine-kiam-health.yaml
@@ -12,7 +12,6 @@ spec:
     #applabel: "app=nginx"
     applabel: "app=kiam"
     appkind: deployment
-  jobCleanUpPolicy: retain
   engineState: 'active'
   chaosServiceAccount: chaos-admin
   experiments:

--- a/charts/kube-components/k8-kiam/engine.yaml
+++ b/charts/kube-components/k8-kiam/engine.yaml
@@ -11,7 +11,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-kube-proxy/engine.yaml
+++ b/charts/kube-components/k8-kube-proxy/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-prometheus-k8s-prometheus/engine.yaml
+++ b/charts/kube-components/k8-prometheus-k8s-prometheus/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-prometheus-operator/engine.yaml
+++ b/charts/kube-components/k8-prometheus-operator/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-prometheus-pushgateway/engine.yaml
+++ b/charts/kube-components/k8-prometheus-pushgateway/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/kube-components/k8-wavefront-collector/engine.yaml
+++ b/charts/kube-components/k8-wavefront-collector/engine.yaml
@@ -10,7 +10,6 @@ spec:
     appkind: deployment
   engineState: 'active'
   chaosServiceAccount: chaos-admin
-  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:

--- a/charts/openebs/openebs-control-plane-chaos/engine.yaml
+++ b/charts/openebs/openebs-control-plane-chaos/engine.yaml
@@ -11,8 +11,6 @@ spec:
     applabel: 'name=maya-apiserver'
     appkind: 'deployment'
   chaosServiceAccount: control-plane-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-control-plane-chaos
       spec:

--- a/charts/openebs/openebs-nfs-provisioner-kill/engine.yaml
+++ b/charts/openebs/openebs-nfs-provisioner-kill/engine.yaml
@@ -11,8 +11,6 @@ spec:
     applabel: 'app=minio'
     appkind: 'deployment'
   chaosServiceAccount: nfs-chaos-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-nfs-provisioner-kill
       spec:

--- a/charts/openebs/openebs-pool-container-failure/engine.yaml
+++ b/charts/openebs/openebs-pool-container-failure/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-container-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-pool-container-failure
       spec:

--- a/charts/openebs/openebs-pool-disk-loss/engine.yaml
+++ b/charts/openebs/openebs-pool-disk-loss/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-disk-loss-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-pool-disk-loss
       spec:

--- a/charts/openebs/openebs-pool-network-delay/engine.yaml
+++ b/charts/openebs/openebs-pool-network-delay/engine.yaml
@@ -9,8 +9,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-network-delay-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-pool-network-delay
       spec:

--- a/charts/openebs/openebs-pool-network-loss/engine.yaml
+++ b/charts/openebs/openebs-pool-network-loss/engine.yaml
@@ -12,8 +12,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-network-loss-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-pool-network-loss
       spec:

--- a/charts/openebs/openebs-pool-pod-failure/engine.yaml
+++ b/charts/openebs/openebs-pool-pod-failure/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: pool-pod-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-pool-pod-failure
       spec:

--- a/charts/openebs/openebs-target-container-failure/engine.yaml
+++ b/charts/openebs/openebs-target-container-failure/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-container-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-target-container-failure
       spec:

--- a/charts/openebs/openebs-target-network-delay/engine.yaml
+++ b/charts/openebs/openebs-target-network-delay/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-network-delay-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-target-network-delay
       spec:

--- a/charts/openebs/openebs-target-network-loss/engine.yaml
+++ b/charts/openebs/openebs-target-network-loss/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-network-loss-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-target-network-loss
       spec:

--- a/charts/openebs/openebs-target-pod-failure/engine.yaml
+++ b/charts/openebs/openebs-target-pod-failure/engine.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: target-pod-failure-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: openebs-target-pod-failure
       spec:

--- a/charts/openebs/sample_openebs_engine_with_data_persistency_enabled.yaml
+++ b/charts/openebs/sample_openebs_engine_with_data_persistency_enabled.yaml
@@ -13,8 +13,6 @@ spec:
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: <experiments-name>-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: <experiments-name>
       spec:

--- a/charts/vmware/vm-poweroff/engine.yaml
+++ b/charts/vmware/vm-poweroff/engine.yaml
@@ -9,8 +9,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: vm-poweroff-sa
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
   experiments:
     - name: vm-poweroff
       spec:

--- a/service-accounts/argowf-chaos-admin.yaml
+++ b/service-accounts/argowf-chaos-admin.yaml
@@ -42,7 +42,6 @@ spec:
                   appns: {{workflow.parameters.appNamespace}}
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: litmus-admin
                 experiments:

--- a/workflows/k8-calico-node/workflow.yaml
+++ b/workflows/k8-calico-node/workflow.yaml
@@ -74,7 +74,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:
@@ -124,7 +124,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:

--- a/workflows/k8-kiam/workflow.yaml
+++ b/workflows/k8-kiam/workflow.yaml
@@ -74,7 +74,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:
@@ -124,7 +124,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:

--- a/workflows/k8-pod-delete/workflow.yaml
+++ b/workflows/k8-pod-delete/workflow.yaml
@@ -97,7 +97,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:
@@ -147,7 +147,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:

--- a/workflows/k8-service-kill/workflow.yaml
+++ b/workflows/k8-service-kill/workflow.yaml
@@ -74,7 +74,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:
@@ -124,7 +124,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:

--- a/workflows/k8-wavefront-collector/workflow.yaml
+++ b/workflows/k8-wavefront-collector/workflow.yaml
@@ -74,7 +74,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:
@@ -124,7 +124,7 @@ spec:
                   #applabel: "app=nginx"
                   applabel: "app={{workflow.parameters.appLabel}}"
                   appkind: deployment
-                jobCleanUpPolicy: delete
+                jobCleanUpPolicy: retain
                 engineState: 'active'
                 chaosServiceAccount: {{workflow.parameters.chaosServiceAccount}}
                 experiments:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

- Added retain as the default jobCleanUpPolicy inside all chaos workflows
- Removed the jobCleanUpPolicy field from the chaosengine as it sets default value as retain. It can be provided inside chaosengine if jobCleanUpPolicy has to be deleted.

- Removed annotationCheck field inside chaosengine. It contains default value as false and should be provided inside chaosengine if the annotation check is required. 