### PR TITLE
Chore(charts): Update docker service kill charts from ansible to litmus-go

### DIFF
--- a/charts/generic/docker-service-kill/docker-service-kill.chartserviceversion.yaml
+++ b/charts/generic/docker-service-kill/docker-service-kill.chartserviceversion.yaml
@@ -34,7 +34,7 @@ spec:
     app.kubernetes.io/version: latest
   links:
     - name: Source Code
-      url: https://github.com/litmuschaos/litmus-ansible/tree/master/experiments/generic/docker_service_kill
+      url: https://github.com/litmuschaos/litmus-go/tree/master/experiments/generic/docker-service-kill
     - name: Documentation
       url: https://docs.litmuschaos.io/docs/docker-service-kill/
     - name: Video

--- a/charts/generic/docker-service-kill/engine.yaml
+++ b/charts/generic/docker-service-kill/engine.yaml
@@ -4,13 +4,8 @@ metadata:
   name: nginx-chaos
   namespace: default
 spec:
-  appinfo:
-    appns: 'default'
-    applabel: 'app=nginx'
-    appkind: 'deployment'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: docker-service-kill-sa
   experiments:
@@ -21,10 +16,8 @@ spec:
         #   # provide the node labels
         #   kubernetes.io/hostname: 'node02'
           env:
-            # set chaos duration (in sec) as desired
             - name: TOTAL_CHAOS_DURATION
-              value: '90'
-
-             # provide the actual name of node under test
-            - name: APP_NODE
+              value: '90' # in seconds
+              
+            - name: TARGET_NODE
               value: 'node-01'

--- a/charts/generic/docker-service-kill/experiment.yaml
+++ b/charts/generic/docker-service-kill/experiment.yaml
@@ -41,17 +41,15 @@ spec:
         verbs:
           - "get"
           - "list"
-    image: "litmuschaos/ansible-runner:ci"
+    image: "litmuschaos/go-runner:latest"
     imagePullPolicy: Always
     args:
     - -c
-    - ansible-playbook ./experiments/generic/docker_service_kill/docker_service_kill_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0
+    - ./experiments -name docker-service-kill
     command:
     - /bin/bash
     env:
-    - name: ANSIBLE_STDOUT_CALLBACK
-      value: 'default'
-
+    
     - name: TOTAL_CHAOS_DURATION
       value: '90' # in seconds
 
@@ -61,6 +59,18 @@ spec:
 
     - name: LIB
       value: 'litmus'
+
+    - name: NODE_LABEL
+      value: ''
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: 'ubuntu:16.04' 
+            
+    # provide the target node name
+    - name: TARGET_NODE
+      value: ''
+
     labels:
       name: docker-service-kill
       app.kubernetes.io/part-of: litmus


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>

#### This PR adds:

- Update docker service kill charts from ansible to go.