### PR TITLE
Added default kill command in experiment.yaml

### DIFF
--- a/charts/cassandra/cassandra-pod-delete/engine.yaml
+++ b/charts/cassandra/cassandra-pod-delete/engine.yaml
@@ -45,7 +45,7 @@ spec:
               value: '9042'
 
             # SET THE CASSANDRA_LIVENESS_CHECK
-            # IT CAN BE `enabled` OR `disabled`
+            # IT CAN BE `enable` OR `disable`
             - name: CASSANDRA_LIVENESS_CHECK
               value: ''
 

--- a/charts/cassandra/cassandra-pod-delete/experiment.yaml
+++ b/charts/cassandra/cassandra-pod-delete/experiment.yaml
@@ -82,7 +82,7 @@ spec:
       value: '15'
 
     # SET THE CASSANDRA_LIVENESS_CHECK
-    # IT CAN BE `enabled` OR `disabled`
+    # IT CAN BE `enable` OR `disable`
     - name: CASSANDRA_LIVENESS_CHECK
       value: ''
 

--- a/charts/generic/pod-cpu-hog-exec/experiment.yaml
+++ b/charts/generic/pod-cpu-hog-exec/experiment.yaml
@@ -72,6 +72,10 @@ spec:
     ## default: litmus. Supported values: litmus    
     - name: LIB
       value: 'litmus'
+    
+    # The command to kill the chaos process
+    - name: CHAOS_KILL_COMMAND
+      value: "kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}')"
 
     - name: TARGET_PODS
       value: ''

--- a/charts/generic/pod-memory-hog-exec/experiment.yaml
+++ b/charts/generic/pod-memory-hog-exec/experiment.yaml
@@ -73,6 +73,10 @@ spec:
       ## default: litmus. Supported values: litmus
       - name: LIB
         value: 'litmus'
+      
+      # The command to kill the chaos process
+      - name: CHAOS_KILL_COMMAND
+        value: "kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' | head -n 1)"
         
       ## it defines the sequence of chaos execution for multiple target pods
       ## supported values: serial, parallel


### PR DESCRIPTION
This PR adds default kill command to the pod-memory-hog-exec and pod-cpu-hog-exec experiment.yaml
Signed-off-by: Akash Shrivastava <akash@chaosnative.com>