### PR TITLE
Upgrading charts version to 2.4.0

### DIFF
--- a/workflows/bank-of-anthos/workflow.yaml
+++ b/workflows/bank-of-anthos/workflow.yaml
@@ -41,7 +41,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"      
     
     - name: pod-network-loss

--- a/workflows/bank-of-anthos/workflow_cron.yaml
+++ b/workflows/bank-of-anthos/workflow_cron.yaml
@@ -45,7 +45,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"      
     
     - name: pod-network-loss

--- a/workflows/k8-pod-delete/workflow.yaml
+++ b/workflows/k8-pod-delete/workflow.yaml
@@ -63,7 +63,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/byoc-pod-delete/experiment.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/byoc-pod-delete/experiment.yaml -n
             {{workflow.parameters.appNamespace}} | sleep 30"
     
     - name: install-chaos-rbac
@@ -71,7 +71,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/byoc-pod-delete/rbac.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/byoc-pod-delete/rbac.yaml -n
             {{workflow.parameters.appNamespace}} | sleep 30"
 
     - name: run-chaos
@@ -179,7 +179,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl delete -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/byoc-pod-delete/experiment.yaml -n
+          - "kubectl delete -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/byoc-pod-delete/experiment.yaml -n
             {{workflow.parameters.appNamespace}} | sleep 30"
     
     - name: revert-chaos-rbac
@@ -187,5 +187,5 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl delete -f https://hub.litmuschaos.io/api/chaos/1.9.0?file=charts/generic/byoc-pod-delete/rbac.yaml -n
+          - "kubectl delete -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/byoc-pod-delete/rbac.yaml -n
             {{workflow.parameters.appNamespace}} | sleep 30"

--- a/workflows/kube-proxy-all/workflow.yaml
+++ b/workflows/kube-proxy-all/workflow.yaml
@@ -45,7 +45,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} | sleep 30"
 
     - name: node-cpu-hog

--- a/workflows/kube-proxy-all/workflow_cron.yaml
+++ b/workflows/kube-proxy-all/workflow_cron.yaml
@@ -48,7 +48,7 @@ spec:
           image: litmuschaos/k8s:latest
           command: [sh, -c]
           args:
-            - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+            - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
               {{workflow.parameters.adminModeNamespace}} | sleep 30"
 
       - name: node-cpu-hog

--- a/workflows/namespaced-scope-chaos/workflow.yaml
+++ b/workflows/namespaced-scope-chaos/workflow.yaml
@@ -71,7 +71,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:latest"
+                    image: "litmuschaos/go-runner:2.4.0"
                     imagePullPolicy: Always
                     args:
                     - -c

--- a/workflows/namespaced-scope-chaos/workflow_cron.yaml
+++ b/workflows/namespaced-scope-chaos/workflow_cron.yaml
@@ -75,7 +75,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:latest"
+                      image: "litmuschaos/go-runner:2.4.0"
                       imagePullPolicy: Always
                       args:
                       - -c

--- a/workflows/node-cpu-hog/workflow.yaml
+++ b/workflows/node-cpu-hog/workflow.yaml
@@ -72,7 +72,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:latest"
+                    image: "litmuschaos/go-runner:2.4.0"
                     imagePullPolicy: Always
                     args:
                     - -c
@@ -100,7 +100,7 @@ spec:
 
                     # provide lib image
                     - name: LIB_IMAGE
-                      value: 'litmuschaos/go-runner:latest' 
+                      value: 'litmuschaos/go-runner:2.4.0' 
                   
                     labels:
                       name: node-cpu-hog

--- a/workflows/node-cpu-hog/workflow_cron.yaml
+++ b/workflows/node-cpu-hog/workflow_cron.yaml
@@ -76,7 +76,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:latest"
+                      image: "litmuschaos/go-runner:2.4.0"
                       imagePullPolicy: Always
                       args:
                       - -c
@@ -104,7 +104,7 @@ spec:
 
                       # provide lib image
                       - name: LIB_IMAGE
-                        value: 'litmuschaos/go-runner:latest' 
+                        value: 'litmuschaos/go-runner:2.4.0' 
                     
                       labels:
                         name: node-cpu-hog

--- a/workflows/node-memory-hog/workflow.yaml
+++ b/workflows/node-memory-hog/workflow.yaml
@@ -72,7 +72,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:latest"
+                    image: "litmuschaos/go-runner:2.4.0"
                     imagePullPolicy: Always
                     args:
                     - -c
@@ -100,7 +100,7 @@ spec:
 
                     # provide lib image
                     - name: LIB_IMAGE
-                      value: 'litmuschaos/go-runner:latest' 
+                      value: 'litmuschaos/go-runner:2.4.0' 
                       
                     labels:
                       name: node-memory-hog

--- a/workflows/node-memory-hog/workflow_cron.yaml
+++ b/workflows/node-memory-hog/workflow_cron.yaml
@@ -75,7 +75,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:latest"
+                      image: "litmuschaos/go-runner:2.4.0"
                       imagePullPolicy: Always
                       args:
                       - -c
@@ -98,7 +98,7 @@ spec:
                         value: 'litmus'
                       # provide lib image
                       - name: LIB_IMAGE
-                        value: 'litmuschaos/go-runner:latest' 
+                        value: 'litmuschaos/go-runner:2.4.0' 
                       labels:
                         name: node-memory-hog
         container:

--- a/workflows/pod-cpu-hog/workflow.yaml
+++ b/workflows/pod-cpu-hog/workflow.yaml
@@ -64,7 +64,7 @@ spec:
                           - "patch"
                           - "update"
                           - "delete"
-                    image: "litmuschaos/go-runner:latest"
+                    image: "litmuschaos/go-runner:2.4.0"
                     imagePullPolicy: Always
                     args:
                     - -c

--- a/workflows/pod-cpu-hog/workflow_cron.yaml
+++ b/workflows/pod-cpu-hog/workflow_cron.yaml
@@ -68,7 +68,7 @@ spec:
                             - "patch"
                             - "update"
                             - "delete"
-                      image: "litmuschaos/go-runner:latest"
+                      image: "litmuschaos/go-runner:2.4.0"
                       imagePullPolicy: Always
                       args:
                       - -c

--- a/workflows/pod-delete/workflow.yaml
+++ b/workflows/pod-delete/workflow.yaml
@@ -74,7 +74,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:latest"
+                    image: "litmuschaos/go-runner:2.4.0"
                     imagePullPolicy: Always
                     args:
                     - -c

--- a/workflows/pod-delete/workflow_cron.yaml
+++ b/workflows/pod-delete/workflow_cron.yaml
@@ -78,7 +78,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:latest"
+                      image: "litmuschaos/go-runner:2.4.0"
                       imagePullPolicy: Always
                       args:
                       - -c

--- a/workflows/pod-memory-hog/workflow.yaml
+++ b/workflows/pod-memory-hog/workflow.yaml
@@ -64,7 +64,7 @@ spec:
                           - "patch"
                           - "update"
                           - "delete"
-                    image: "litmuschaos/go-runner:latest"
+                    image: "litmuschaos/go-runner:2.4.0"
                     args:
                     - -c
                     - ./experiments -name pod-memory-hog

--- a/workflows/pod-memory-hog/workflow_cron.yaml
+++ b/workflows/pod-memory-hog/workflow_cron.yaml
@@ -68,7 +68,7 @@ spec:
                             - "patch"
                             - "update"
                             - "delete"
-                      image: "litmuschaos/go-runner:latest"
+                      image: "litmuschaos/go-runner:2.4.0"
                       args:
                       - -c
                       - ./experiments -name pod-memory-hog

--- a/workflows/podtato-head/workflow.yaml
+++ b/workflows/podtato-head/workflow.yaml
@@ -39,7 +39,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"
 
     - name: pod-delete

--- a/workflows/podtato-head/workflow_cron.yaml
+++ b/workflows/podtato-head/workflow_cron.yaml
@@ -43,7 +43,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"
 
     - name: pod-delete

--- a/workflows/sock-shop-promProbe/workflow.yaml
+++ b/workflows/sock-shop-promProbe/workflow.yaml
@@ -53,7 +53,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"
         
     - name: pod-cpu-hog

--- a/workflows/sock-shop-promProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-promProbe/workflow_cron.yaml
@@ -57,7 +57,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"
         
     - name: pod-cpu-hog

--- a/workflows/sock-shop/workflow.yaml
+++ b/workflows/sock-shop/workflow.yaml
@@ -53,7 +53,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"
 
     - name: pod-cpu-hog

--- a/workflows/sock-shop/workflow_cron.yaml
+++ b/workflows/sock-shop/workflow_cron.yaml
@@ -57,7 +57,7 @@ spec:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/experiments.yaml -n
+          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/2.4.0?file=charts/generic/experiments.yaml -n
             {{workflow.parameters.adminModeNamespace}} ; sleep 30"
 
     - name: pod-cpu-hog


### PR DESCRIPTION


 - Upgrading charts version to 2.4.0, mainly experiment installation hub link and go-runner version