### PR TITLE
Node Memory and CPU hog charts update

### DIFF
--- a/charts/generic/node-cpu-hog/engine.yaml
+++ b/charts/generic/node-cpu-hog/engine.yaml
@@ -18,8 +18,15 @@ spec:
             - name: TOTAL_CHAOS_DURATION
               value: '60'
             
+            ## ENTER THE NUMBER OF CORES OF CPU FOR CPU HOGGING
+            ## OPTIONAL VALUE IN CASE OF EMPTY VALUE IT WILL TAKE NODE CPU CAPACITY 
             - name: NODE_CPU_CORE
-              value: ''
+              value: '1'
+
+            ## LOAD CPU WITH GIVEN PERCENT LOADING FOR THE CPU STRESS WORKERS. 
+            ## 0 IS EFFECTIVELY A SLEEP (NO LOAD) AND 100 IS FULL LOADING
+            - name: CPU_LOAD
+              value: '0'
             
             ## percentage of total nodes to target
             - name: NODES_AFFECTED_PERC

--- a/charts/generic/node-memory-hog/engine.yaml
+++ b/charts/generic/node-memory-hog/engine.yaml
@@ -18,11 +18,6 @@ spec:
             - name: TOTAL_CHAOS_DURATION
               value: '120'
 
-            ## Specify the size as percent of total node capacity Ex: '30'
-            ## Note: For consuming memory in mebibytes change the variable to MEMORY_CONSUMPTION_MEBIBYTES
-            - name: MEMORY_CONSUMPTION_PERCENTAGE
-              value: '30'
-            
             ## percentage of total nodes to target
             - name: NODES_AFFECTED_PERC
               value: ''
@@ -30,3 +25,13 @@ spec:
             # provide the comma separated target node names
             - name: TARGET_NODES
               value: ''
+            
+            ## Specify the size as percent of total node capacity Ex: '30'
+            ## NOTE: for selecting this option keep MEMORY_CONSUMPTION_MEBIBYTES empty
+            - name: MEMORY_CONSUMPTION_PERCENTAGE
+              value: '0'
+              
+            ## Specify the amount of memory to be consumed in mebibytes
+            ## NOTE: for selecting this option keep MEMORY_CONSUMPTION_PERCENTAGE empty
+            - name: MEMORY_CONSUMPTION_MEBIBYTES
+              value: '0'


### PR DESCRIPTION
This PR adds
1. `CPU_LOAD` (default 0) and `NODE_CPU_CORE` (default 1) to node-cpu-hog
2. `MEMORY_CONSUMPTION_PERCENTAGE` (default 0) and `MEMORY_CONSUMPTION_MEBIBYTES` (default 0)

Signed-off-by: Akash Shrivastava <as86414@gmail.com>