### PR TITLE
chore: Upgrade go-runner image tag to 3.0.0-beta10

### DIFF
--- a/experiments/namespaced-scope-chaos/experiment.yaml
+++ b/experiments/namespaced-scope-chaos/experiment.yaml
@@ -71,7 +71,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:3.0.0-beta3"
+                    image: "litmuschaos/go-runner:3.0.0-beta10"
                     imagePullPolicy: Always
                     args:
                     - -c

--- a/experiments/namespaced-scope-chaos/experiment_cron.yaml
+++ b/experiments/namespaced-scope-chaos/experiment_cron.yaml
@@ -75,7 +75,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:3.0.0-beta3"
+                      image: "litmuschaos/go-runner:3.0.0-beta10"
                       imagePullPolicy: Always
                       args:
                       - -c

--- a/experiments/node-cpu-hog/experiment.yaml
+++ b/experiments/node-cpu-hog/experiment.yaml
@@ -72,7 +72,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:3.0.0-beta3"
+                    image: "litmuschaos/go-runner:3.0.0-beta10"
                     imagePullPolicy: Always
                     args:
                     - -c
@@ -95,7 +95,7 @@ spec:
 
                     # provide lib image
                     - name: LIB_IMAGE
-                      value: 'litmuschaos/go-runner:3.0.0-beta3' 
+                      value: 'litmuschaos/go-runner:3.0.0-beta10' 
                   
                     labels:
                       name: node-cpu-hog

--- a/experiments/node-cpu-hog/experiment_cron.yaml
+++ b/experiments/node-cpu-hog/experiment_cron.yaml
@@ -76,7 +76,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:3.0.0-beta3"
+                      image: "litmuschaos/go-runner:3.0.0-beta10"
                       imagePullPolicy: Always
                       args:
                       - -c
@@ -99,7 +99,7 @@ spec:
 
                       # provide lib image
                       - name: LIB_IMAGE
-                        value: 'litmuschaos/go-runner:3.0.0-beta3' 
+                        value: 'litmuschaos/go-runner:3.0.0-beta10' 
                     
                       labels:
                         name: node-cpu-hog

--- a/experiments/node-memory-hog/experiment.yaml
+++ b/experiments/node-memory-hog/experiment.yaml
@@ -72,7 +72,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:3.0.0-beta3"
+                    image: "litmuschaos/go-runner:3.0.0-beta10"
                     imagePullPolicy: Always
                     args:
                     - -c
@@ -95,7 +95,7 @@ spec:
 
                     # provide lib image
                     - name: LIB_IMAGE
-                      value: 'litmuschaos/go-runner:3.0.0-beta3' 
+                      value: 'litmuschaos/go-runner:3.0.0-beta10' 
                       
                     labels:
                       name: node-memory-hog

--- a/experiments/node-memory-hog/experiment_cron.yaml
+++ b/experiments/node-memory-hog/experiment_cron.yaml
@@ -75,7 +75,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:3.0.0-beta3"
+                      image: "litmuschaos/go-runner:3.0.0-beta10"
                       imagePullPolicy: Always
                       args:
                       - -c
@@ -94,7 +94,7 @@ spec:
                         value: ''
                       # provide lib image
                       - name: LIB_IMAGE
-                        value: 'litmuschaos/go-runner:3.0.0-beta3' 
+                        value: 'litmuschaos/go-runner:3.0.0-beta10' 
                       labels:
                         name: node-memory-hog
         container:

--- a/experiments/pod-cpu-hog/experiment.yaml
+++ b/experiments/pod-cpu-hog/experiment.yaml
@@ -64,7 +64,7 @@ spec:
                           - "patch"
                           - "update"
                           - "delete"
-                    image: "litmuschaos/go-runner:3.0.0-beta3"
+                    image: "litmuschaos/go-runner:3.0.0-beta10"
                     imagePullPolicy: Always
                     args:
                     - -c

--- a/experiments/pod-cpu-hog/experiment_cron.yaml
+++ b/experiments/pod-cpu-hog/experiment_cron.yaml
@@ -68,7 +68,7 @@ spec:
                             - "patch"
                             - "update"
                             - "delete"
-                      image: "litmuschaos/go-runner:3.0.0-beta3"
+                      image: "litmuschaos/go-runner:3.0.0-beta10"
                       imagePullPolicy: Always
                       args:
                       - -c

--- a/experiments/pod-delete/experiment.yaml
+++ b/experiments/pod-delete/experiment.yaml
@@ -74,7 +74,7 @@ spec:
                         verbs:
                           - "get"
                           - "list"
-                    image: "litmuschaos/go-runner:3.0.0-beta3"
+                    image: "litmuschaos/go-runner:3.0.0-beta10"
                     imagePullPolicy: Always
                     args:
                     - -c

--- a/experiments/pod-delete/experiment_cron.yaml
+++ b/experiments/pod-delete/experiment_cron.yaml
@@ -78,7 +78,7 @@ spec:
                           verbs:
                             - "get"
                             - "list"
-                      image: "litmuschaos/go-runner:3.0.0-beta3"
+                      image: "litmuschaos/go-runner:3.0.0-beta10"
                       imagePullPolicy: Always
                       args:
                       - -c

--- a/experiments/pod-memory-hog/experiment.yaml
+++ b/experiments/pod-memory-hog/experiment.yaml
@@ -64,7 +64,7 @@ spec:
                           - "patch"
                           - "update"
                           - "delete"
-                    image: "litmuschaos/go-runner:3.0.0-beta3"
+                    image: "litmuschaos/go-runner:3.0.0-beta10"
                     args:
                     - -c
                     - ./experiments -name pod-memory-hog

--- a/experiments/pod-memory-hog/experiment_cron.yaml
+++ b/experiments/pod-memory-hog/experiment_cron.yaml
@@ -68,7 +68,7 @@ spec:
                             - "patch"
                             - "update"
                             - "delete"
-                      image: "litmuschaos/go-runner:3.0.0-beta3"
+                      image: "litmuschaos/go-runner:3.0.0-beta10"
                       args:
                       - -c
                       - ./experiments -name pod-memory-hog

--- a/faults/aws/aws-ssm-chaos-by-id/fault.yaml
+++ b/faults/aws/aws-ssm-chaos-by-id/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/aws/aws-ssm-chaos-by-tag/fault.yaml
+++ b/faults/aws/aws-ssm-chaos-by-tag/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/aws/ebs-loss-by-id/fault.yaml
+++ b/faults/aws/ebs-loss-by-id/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/aws/ebs-loss-by-tag/fault.yaml
+++ b/faults/aws/ebs-loss-by-tag/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/aws/ec2-stop-by-tag/fault.yaml
+++ b/faults/aws/ec2-stop-by-tag/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/aws/ec2-terminate-by-id/fault.yaml
+++ b/faults/aws/ec2-terminate-by-id/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/azure/azure-disk-loss/fault.yaml
+++ b/faults/azure/azure-disk-loss/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/azure/azure-instance-stop/fault.yaml
+++ b/faults/azure/azure-instance-stop/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/gcp/gcp-vm-disk-loss-by-label/fault.yaml
+++ b/faults/gcp/gcp-vm-disk-loss-by-label/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/gcp/gcp-vm-disk-loss/fault.yaml
+++ b/faults/gcp/gcp-vm-disk-loss/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/gcp/gcp-vm-instance-stop-by-label/fault.yaml
+++ b/faults/gcp/gcp-vm-instance-stop-by-label/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/gcp/gcp-vm-instance-stop/fault.yaml
+++ b/faults/gcp/gcp-vm-instance-stop/fault.yaml
@@ -43,7 +43,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/container-kill/fault.yaml
+++ b/faults/kubernetes/container-kill/fault.yaml
@@ -58,7 +58,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/disk-fill/fault.yaml
+++ b/faults/kubernetes/disk-fill/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/docker-service-kill/fault.yaml
+++ b/faults/kubernetes/docker-service-kill/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/kubelet-service-kill/fault.yaml
+++ b/faults/kubernetes/kubelet-service-kill/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/node-cpu-hog/fault.yaml
+++ b/faults/kubernetes/node-cpu-hog/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/node-drain/fault.yaml
+++ b/faults/kubernetes/node-drain/fault.yaml
@@ -51,7 +51,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list", "patch"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/node-io-stress/fault.yaml
+++ b/faults/kubernetes/node-io-stress/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/node-memory-hog/fault.yaml
+++ b/faults/kubernetes/node-memory-hog/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/node-poweroff/fault.yaml
+++ b/faults/kubernetes/node-poweroff/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get","list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
     - -c
@@ -70,7 +70,7 @@ spec:
 
     # provide lib image
     - name: LIB_IMAGE
-      value: "litmuschaos/go-runner:3.0.0-beta3"
+      value: "litmuschaos/go-runner:3.0.0-beta10"
 
     # ENTER THE TARGET NODE NAME
     - name: TARGET_NODE

--- a/faults/kubernetes/node-restart/fault.yaml
+++ b/faults/kubernetes/node-restart/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/node-taint/fault.yaml
+++ b/faults/kubernetes/node-taint/fault.yaml
@@ -51,7 +51,7 @@ spec:
       - apiGroups: [""]
         resources: ["nodes"]
         verbs: ["get", "list", "patch", "update"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-autoscaler/fault.yaml
+++ b/faults/kubernetes/pod-autoscaler/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-cpu-hog-exec/fault.yaml
+++ b/faults/kubernetes/pod-cpu-hog-exec/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-cpu-hog/fault.yaml
+++ b/faults/kubernetes/pod-cpu-hog/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-delete/fault.yaml
+++ b/faults/kubernetes/pod-delete/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-dns-error/fault.yaml
+++ b/faults/kubernetes/pod-dns-error/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     args:
       - -c
       - ./experiments -name pod-dns-error

--- a/faults/kubernetes/pod-dns-spoof/fault.yaml
+++ b/faults/kubernetes/pod-dns-spoof/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     args:
       - -c
       - ./experiments -name pod-dns-spoof

--- a/faults/kubernetes/pod-http-latency/fault.yaml
+++ b/faults/kubernetes/pod-http-latency/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-http-modify-body/fault.yaml
+++ b/faults/kubernetes/pod-http-modify-body/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-http-modify-header/fault.yaml
+++ b/faults/kubernetes/pod-http-modify-header/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-http-reset-peer/fault.yaml
+++ b/faults/kubernetes/pod-http-reset-peer/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-http-status-code/fault.yaml
+++ b/faults/kubernetes/pod-http-status-code/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-io-stress/fault.yaml
+++ b/faults/kubernetes/pod-io-stress/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-memory-hog-exec/fault.yaml
+++ b/faults/kubernetes/pod-memory-hog-exec/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-memory-hog/fault.yaml
+++ b/faults/kubernetes/pod-memory-hog/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-network-corruption/fault.yaml
+++ b/faults/kubernetes/pod-network-corruption/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-network-duplication/fault.yaml
+++ b/faults/kubernetes/pod-network-duplication/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-network-latency/fault.yaml
+++ b/faults/kubernetes/pod-network-latency/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-network-loss/fault.yaml
+++ b/faults/kubernetes/pod-network-loss/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/kubernetes/pod-network-partition/fault.yaml
+++ b/faults/kubernetes/pod-network-partition/fault.yaml
@@ -47,7 +47,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/spring-boot/spring-boot-app-kill/fault.yaml
+++ b/faults/spring-boot/spring-boot-app-kill/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/spring-boot/spring-boot-cpu-stress/fault.yaml
+++ b/faults/spring-boot/spring-boot-cpu-stress/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/spring-boot/spring-boot-exceptions/fault.yaml
+++ b/faults/spring-boot/spring-boot-exceptions/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/spring-boot/spring-boot-faults/fault.yaml
+++ b/faults/spring-boot/spring-boot-faults/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/spring-boot/spring-boot-latency/fault.yaml
+++ b/faults/spring-boot/spring-boot-latency/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/spring-boot/spring-boot-memory-stress/fault.yaml
+++ b/faults/spring-boot/spring-boot-memory-stress/fault.yaml
@@ -39,7 +39,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c

--- a/faults/vmware/vm-poweroff/fault.yaml
+++ b/faults/vmware/vm-poweroff/fault.yaml
@@ -59,7 +59,7 @@ spec:
       - apiGroups: ["litmuschaos.io"]
         resources: ["chaosengines", "chaosexperiments", "chaosresults"]
         verbs: ["create", "list", "get", "patch", "update", "delete"]
-    image: "litmuschaos/go-runner:3.0.0-beta3"
+    image: "litmuschaos/go-runner:3.0.0-beta10"
     imagePullPolicy: Always
     args:
       - -c


### PR DESCRIPTION
Upgrades go-runner image tag from 3.0.0-beta3 to 3.0.0-beta10.