### PR TITLE
chore: Fix experiments charts for 3.0.0

### DIFF
--- a/experiments/bank-of-anthos/experiment.yaml
+++ b/experiments/bank-of-anthos/experiment.yaml
@@ -54,7 +54,7 @@ spec:
                     name: pod-network-loss
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -187,7 +187,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/bank-of-anthos/experiment.yaml
+++ b/experiments/bank-of-anthos/experiment.yaml
@@ -214,7 +214,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_bank-of-anthos"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'bank'

--- a/experiments/bank-of-anthos/experiment.yaml
+++ b/experiments/bank-of-anthos/experiment.yaml
@@ -37,12 +37,168 @@ spec:
         args: ["-namespace=bank","-typeName=resilient","-operation=apply","-timeout=400", "-app=bank-of-anthos","-scope=cluster"] #for weak provide type flagName as resilient(-typeName=weak)
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-network-loss-x1w
+            path: /tmp/pod-network-loss-x1w.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects network packet loss on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-network-loss
+                  labels:
+                    name: pod-network-loss
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-network-loss
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      # provide lib image
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      - name: NETWORK_INTERFACE
+                        value: "eth0"
+
+                      - name: TC_IMAGE
+                        value: "gaiadocker/iproute2"
+
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "100" #in PERCENTAGE
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60" # in seconds
+
+                      # time period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      # provide the name of container runtime
+                      # for litmus LIB, it supports docker, containerd, crio
+                      # for pumba LIB, it supports docker only
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the destination ips
+                      # chaos injection will be triggered for these destination ips
+                      - name: DESTINATION_IPS
+                        value: ""
+
+                      # provide the destination hosts
+                      # chaos injection will be triggered for these destination hosts
+                      - name: DESTINATION_HOSTS
+                        value: ""
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-network-loss
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+          - kubectl apply -f /tmp/pod-network-loss-x1w.yaml -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
 
     - name: pod-network-loss
       inputs:
@@ -58,6 +214,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_bank-of-anthos"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'bank'

--- a/experiments/bank-of-anthos/experiment_cron.yaml
+++ b/experiments/bank-of-anthos/experiment_cron.yaml
@@ -58,7 +58,7 @@ spec:
                     name: pod-network-loss
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -191,7 +191,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/bank-of-anthos/experiment_cron.yaml
+++ b/experiments/bank-of-anthos/experiment_cron.yaml
@@ -218,7 +218,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_bank-of-anthos"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'bank'

--- a/experiments/bank-of-anthos/experiment_cron.yaml
+++ b/experiments/bank-of-anthos/experiment_cron.yaml
@@ -41,13 +41,169 @@ spec:
         args: ["-namespace=bank","-typeName=resilient","-operation=apply","-timeout=400", "-app=bank-of-anthos","-scope=cluster"] #for weak provide type flagName as resilient(-typeName=weak)
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-network-loss-x1w
+            path: /tmp/pod-network-loss-x1w.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects network packet loss on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-network-loss
+                  labels:
+                    name: pod-network-loss
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-network-loss
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      # provide lib image
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      - name: NETWORK_INTERFACE
+                        value: "eth0"
+
+                      - name: TC_IMAGE
+                        value: "gaiadocker/iproute2"
+
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "100" #in PERCENTAGE
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60" # in seconds
+
+                      # time period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      # provide the name of container runtime
+                      # for litmus LIB, it supports docker, containerd, crio
+                      # for pumba LIB, it supports docker only
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the destination ips
+                      # chaos injection will be triggered for these destination ips
+                      - name: DESTINATION_IPS
+                        value: ""
+
+                      # provide the destination hosts
+                      # chaos injection will be triggered for these destination hosts
+                      - name: DESTINATION_HOSTS
+                        value: ""
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-network-loss
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"      
-    
+          - kubectl apply -f /tmp/pod-network-loss-x1w.yaml -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
+
     - name: pod-network-loss
       inputs:
         artifacts:
@@ -62,6 +218,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_bank-of-anthos"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'bank'
@@ -94,29 +251,29 @@ spec:
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
-                              value: '60' 
+                              value: '60'
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
-                              value: 'containerd' 
+                              value: 'containerd'
                             - name: SOCKET_PATH
-                              value: '/run/containerd/containerd.sock'                
+                              value: '/run/containerd/containerd.sock'
       container:
         image: litmuschaos/litmus-checker:latest
-        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"] 
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
 
     - name: delete-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
-        args: ["-namespace=bank","-typeName=resilient","-operation=delete", "-app=bank-of-anthos"]  
-    
+        args: ["-namespace=bank","-typeName=resilient","-operation=delete", "-app=bank-of-anthos"]
+
     - name: cleanup-chaos-resources
       container:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
-        args: 
-          [ 
+        args:
+          [
             "kubectl delete chaosengine pod-network-loss-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/namespaced-scope-chaos/experiment.yaml
+++ b/experiments/namespaced-scope-chaos/experiment.yaml
@@ -66,7 +66,7 @@ spec:
                           - "delete"
                       - apiGroups:
                           - ""
-                        resources: 
+                        resources:
                           - "nodes"
                         verbs:
                           - "get"
@@ -125,6 +125,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.adminModeNamespace}}_hello-world"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}

--- a/experiments/namespaced-scope-chaos/experiment.yaml
+++ b/experiments/namespaced-scope-chaos/experiment.yaml
@@ -125,7 +125,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.adminModeNamespace}}_hello-world"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}

--- a/experiments/namespaced-scope-chaos/experiment_cron.yaml
+++ b/experiments/namespaced-scope-chaos/experiment_cron.yaml
@@ -129,7 +129,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.adminModeNamespace}}_hello-world"
-                    annotation: {}
+                    annotations: {}
                   spec:
                     appinfo:
                       appns: {{workflow.parameters.adminModeNamespace}}

--- a/experiments/namespaced-scope-chaos/experiment_cron.yaml
+++ b/experiments/namespaced-scope-chaos/experiment_cron.yaml
@@ -70,7 +70,7 @@ spec:
                             - "delete"
                         - apiGroups:
                             - ""
-                          resources: 
+                          resources:
                             - "nodes"
                           verbs:
                             - "get"
@@ -129,6 +129,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.adminModeNamespace}}_hello-world"
+                    annotation: {}
                   spec:
                     appinfo:
                       appns: {{workflow.parameters.adminModeNamespace}}

--- a/experiments/node-cpu-hog/experiment.yaml
+++ b/experiments/node-cpu-hog/experiment.yaml
@@ -67,7 +67,7 @@ spec:
                           - "delete"
                       - apiGroups:
                           - ""
-                        resources: 
+                        resources:
                           - "nodes"
                         verbs:
                           - "get"
@@ -89,14 +89,14 @@ spec:
                       value: ''
 
                     ## ENTER THE NUMBER OF CORES OF CPU FOR CPU HOGGING
-                    ## OPTIONAL VALUE IN CASE OF EMPTY VALUE IT WILL TAKE NODE CPU CAPACITY 
+                    ## OPTIONAL VALUE IN CASE OF EMPTY VALUE IT WILL TAKE NODE CPU CAPACITY
                     - name: NODE_CPU_CORE
                       value: ''
 
                     # provide lib image
                     - name: LIB_IMAGE
-                      value: 'litmuschaos/go-runner:latest' 
-                  
+                      value: 'litmuschaos/go-runner:latest'
+
                     labels:
                       name: node-cpu-hog
       container:
@@ -121,6 +121,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.context}}"
+                  annotation: {}
                 spec:
                   jobCleanUpPolicy: retain
                   engineState: 'active'

--- a/experiments/node-cpu-hog/experiment.yaml
+++ b/experiments/node-cpu-hog/experiment.yaml
@@ -121,7 +121,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.context}}"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   jobCleanUpPolicy: retain
                   engineState: 'active'

--- a/experiments/node-cpu-hog/experiment_cron.yaml
+++ b/experiments/node-cpu-hog/experiment_cron.yaml
@@ -71,7 +71,7 @@ spec:
                             - "delete"
                         - apiGroups:
                             - ""
-                          resources: 
+                          resources:
                             - "nodes"
                           verbs:
                             - "get"
@@ -99,8 +99,8 @@ spec:
 
                       # provide lib image
                       - name: LIB_IMAGE
-                        value: 'litmuschaos/go-runner:latest' 
-                    
+                        value: 'litmuschaos/go-runner:latest'
+
                       labels:
                         name: node-cpu-hog
         container:
@@ -125,6 +125,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.context}}"
+                    annotation: {}
                   spec:
                     jobCleanUpPolicy: retain
                     engineState: 'active'

--- a/experiments/node-cpu-hog/experiment_cron.yaml
+++ b/experiments/node-cpu-hog/experiment_cron.yaml
@@ -125,7 +125,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.context}}"
-                    annotation: {}
+                    annotations: {}
                   spec:
                     jobCleanUpPolicy: retain
                     engineState: 'active'

--- a/experiments/node-memory-hog/experiment.yaml
+++ b/experiments/node-memory-hog/experiment.yaml
@@ -67,7 +67,7 @@ spec:
                           - "delete"
                       - apiGroups:
                           - ""
-                        resources: 
+                        resources:
                           - "nodes"
                         verbs:
                           - "get"
@@ -87,7 +87,7 @@ spec:
                     ## specify the size as percent of total available memory (in percentage)
                     ## Default value "90"
                     - name: MEMORY_PERCENTAGE
-                      value: '90'        
+                      value: '90'
 
                     # Period to wait before and after injection of chaos in sec
                     - name: RAMP_TIME
@@ -95,8 +95,8 @@ spec:
 
                     # provide lib image
                     - name: LIB_IMAGE
-                      value: 'litmuschaos/go-runner:latest' 
-                      
+                      value: 'litmuschaos/go-runner:latest'
+
                     labels:
                       name: node-memory-hog
       container:
@@ -121,6 +121,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.context}}"
+                  annotation: {}
                 spec:
                   jobCleanUpPolicy: retain
                   engineState: 'active'

--- a/experiments/node-memory-hog/experiment.yaml
+++ b/experiments/node-memory-hog/experiment.yaml
@@ -121,7 +121,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.context}}"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   jobCleanUpPolicy: retain
                   engineState: 'active'

--- a/experiments/node-memory-hog/experiment_cron.yaml
+++ b/experiments/node-memory-hog/experiment_cron.yaml
@@ -70,7 +70,7 @@ spec:
                             - "delete"
                         - apiGroups:
                             - ""
-                          resources: 
+                          resources:
                             - "nodes"
                           verbs:
                             - "get"
@@ -88,13 +88,13 @@ spec:
                       ## specify the size as percent of total available memory (in percentage)
                       ## Default value "90"
                       - name: MEMORY_PERCENTAGE
-                        value: '90'        
+                        value: '90'
                       # Period to wait before and after injection of chaos in sec
                       - name: RAMP_TIME
                         value: ''
                       # provide lib image
                       - name: LIB_IMAGE
-                        value: 'litmuschaos/go-runner:latest' 
+                        value: 'litmuschaos/go-runner:latest'
                       labels:
                         name: node-memory-hog
         container:
@@ -118,6 +118,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.context}}"
+                    annotation: {}
                   spec:
                     jobCleanUpPolicy: retain
                     engineState: 'active'

--- a/experiments/node-memory-hog/experiment_cron.yaml
+++ b/experiments/node-memory-hog/experiment_cron.yaml
@@ -118,7 +118,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.context}}"
-                    annotation: {}
+                    annotations: {}
                   spec:
                     jobCleanUpPolicy: retain
                     engineState: 'active'

--- a/experiments/pod-cpu-hog/experiment.yaml
+++ b/experiments/pod-cpu-hog/experiment.yaml
@@ -117,7 +117,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_kube-proxy"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: kube-system

--- a/experiments/pod-cpu-hog/experiment.yaml
+++ b/experiments/pod-cpu-hog/experiment.yaml
@@ -74,7 +74,7 @@ spec:
                     env:
                     - name: TOTAL_CHAOS_DURATION
                       value: '30'
-                    
+
                     - name: CHAOS_INTERVAL
                       value: '10'
 
@@ -92,7 +92,7 @@ spec:
 
                     - name: TARGET_POD
                       value: ''
-                      
+
                     labels:
                       name: pod-cpu-hog
       container:
@@ -117,6 +117,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: kube-system

--- a/experiments/pod-cpu-hog/experiment_cron.yaml
+++ b/experiments/pod-cpu-hog/experiment_cron.yaml
@@ -121,7 +121,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.appNamespace}}_kube-proxy"
-                    annotation: {}
+                    annotations: {}
                   spec:
                     appinfo:
                       appns: kube-system

--- a/experiments/pod-cpu-hog/experiment_cron.yaml
+++ b/experiments/pod-cpu-hog/experiment_cron.yaml
@@ -78,7 +78,7 @@ spec:
                       env:
                       - name: TOTAL_CHAOS_DURATION
                         value: '30'
-                      
+
                       - name: CHAOS_INTERVAL
                         value: '10'
 
@@ -96,7 +96,7 @@ spec:
 
                       - name: TARGET_POD
                         value: ''
-                        
+
                       labels:
                         name: pod-cpu-hog
         container:
@@ -121,6 +121,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                    annotation: {}
                   spec:
                     appinfo:
                       appns: kube-system

--- a/experiments/pod-delete/experiment.yaml
+++ b/experiments/pod-delete/experiment.yaml
@@ -69,7 +69,7 @@ spec:
                           - "delete"
                       - apiGroups:
                           - ""
-                        resources: 
+                        resources:
                           - "nodes"
                         verbs:
                           - "get"
@@ -124,6 +124,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: kube-system

--- a/experiments/pod-delete/experiment.yaml
+++ b/experiments/pod-delete/experiment.yaml
@@ -124,7 +124,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_kube-proxy"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: kube-system

--- a/experiments/pod-delete/experiment_cron.yaml
+++ b/experiments/pod-delete/experiment_cron.yaml
@@ -73,7 +73,7 @@ spec:
                             - "delete"
                         - apiGroups:
                             - ""
-                          resources: 
+                          resources:
                             - "nodes"
                           verbs:
                             - "get"
@@ -128,6 +128,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                    annotation: {}
                   spec:
                     appinfo:
                       appns: kube-system

--- a/experiments/pod-delete/experiment_cron.yaml
+++ b/experiments/pod-delete/experiment_cron.yaml
@@ -128,7 +128,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.appNamespace}}_kube-proxy"
-                    annotation: {}
+                    annotations: {}
                   spec:
                     appinfo:
                       appns: kube-system

--- a/experiments/pod-memory-hog/experiment.yaml
+++ b/experiments/pod-memory-hog/experiment.yaml
@@ -87,7 +87,7 @@ spec:
 
                       ## Period to wait before and after injection of chaos in sec
                       - name: RAMP_TIME
-                        value: ''     
+                        value: ''
 
                       - name: TARGET_POD
                         value: ''
@@ -116,6 +116,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: kube-system

--- a/experiments/pod-memory-hog/experiment.yaml
+++ b/experiments/pod-memory-hog/experiment.yaml
@@ -116,7 +116,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_kube-proxy"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: kube-system

--- a/experiments/pod-memory-hog/experiment_cron.yaml
+++ b/experiments/pod-memory-hog/experiment_cron.yaml
@@ -120,6 +120,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                    annotation: {}
                   spec:
                     appinfo:
                       appns: kube-system

--- a/experiments/pod-memory-hog/experiment_cron.yaml
+++ b/experiments/pod-memory-hog/experiment_cron.yaml
@@ -120,7 +120,7 @@ spec:
                     namespace: {{workflow.parameters.adminModeNamespace}}
                     labels:
                       context: "{{workflow.parameters.appNamespace}}_kube-proxy"
-                    annotation: {}
+                    annotations: {}
                   spec:
                     appinfo:
                       appns: kube-system

--- a/experiments/podtato-head/experiment.yaml
+++ b/experiments/podtato-head/experiment.yaml
@@ -184,7 +184,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.adminModeNamespace}}_podtato-main"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}

--- a/experiments/podtato-head/experiment.yaml
+++ b/experiments/podtato-head/experiment.yaml
@@ -35,12 +35,140 @@ spec:
         args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=apply","-timeout=400", "-app=podtato-head","-scope=namespace"]
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-delete-rm5
+            path: /tmp/pod-delete-rm5.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      - name: FORCE
+                        value: "true"
+
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+          - kubectl apply -f /tmp/pod-delete-rm5.yaml -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
 
     - name: pod-delete
       inputs:
@@ -56,6 +184,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.adminModeNamespace}}_podtato-main"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}
@@ -97,18 +226,18 @@ spec:
                               value: 'false'
       container:
         image: litmuschaos/litmus-checker:latest
-        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]        
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
 
     - name: delete-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
         args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=delete","-app=podtato-head"]
-    
+
     - name: cleanup-chaos-resources
       container:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
-        args: 
-          [ 
+        args:
+          [
             "kubectl delete chaosengine podtato-main-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/podtato-head/experiment.yaml
+++ b/experiments/podtato-head/experiment.yaml
@@ -52,7 +52,7 @@ spec:
                     name: pod-delete
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -157,7 +157,7 @@ spec:
                       name: pod-delete
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/podtato-head/experiment_cron.yaml
+++ b/experiments/podtato-head/experiment_cron.yaml
@@ -39,12 +39,140 @@ spec:
         args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=apply","-timeout=400", "-app=podtato-head","-scope=namespace"]
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-delete-rm5
+            path: /tmp/pod-delete-rm5.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      - name: FORCE
+                        value: "true"
+
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+          - kubectl apply -f /tmp/pod-delete-rm5.yaml -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
 
     - name: pod-delete
       inputs:
@@ -60,6 +188,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.adminModeNamespace}}_podtato-main"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}
@@ -107,12 +236,12 @@ spec:
       container:
         image: litmuschaos/litmus-app-deployer:latest
         args: ["-namespace={{workflow.parameters.adminModeNamespace}}","-typeName=resilient","-operation=delete","-app=podtato-head"]
-    
+
     - name: cleanup-chaos-resources
       container:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
-        args: 
-          [ 
+        args:
+          [
             "kubectl delete chaosengine podtato-main-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/podtato-head/experiment_cron.yaml
+++ b/experiments/podtato-head/experiment_cron.yaml
@@ -188,7 +188,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.adminModeNamespace}}_podtato-main"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: {{workflow.parameters.adminModeNamespace}}

--- a/experiments/podtato-head/experiment_cron.yaml
+++ b/experiments/podtato-head/experiment_cron.yaml
@@ -56,7 +56,7 @@ spec:
                     name: pod-delete
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -161,7 +161,7 @@ spec:
                       name: pod-delete
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/sock-shop-promProbe/experiment.yaml
+++ b/experiments/sock-shop-promProbe/experiment.yaml
@@ -66,7 +66,7 @@ spec:
                     name: pod-cpu-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -191,7 +191,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-delete-rm5
             path: /tmp/pod-delete-rm5.yaml
             raw:
@@ -207,7 +207,7 @@ spec:
                     name: pod-delete
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -312,7 +312,7 @@ spec:
                       name: pod-delete
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-network-loss-x1w
             path: /tmp/pod-network-loss-x1w.yaml
             raw:
@@ -328,7 +328,7 @@ spec:
                     name: pod-network-loss
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -461,7 +461,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-memory-hog-49a
             path: /tmp/pod-memory-hog-49a.yaml
             raw:
@@ -477,7 +477,7 @@ spec:
                     name: pod-memory-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -601,7 +601,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: disk-fill-h7d
             path: /tmp/disk-fill-h7d.yaml
             raw:
@@ -617,7 +617,7 @@ spec:
                     name: disk-fill
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -736,7 +736,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/host-path-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/sock-shop-promProbe/experiment.yaml
+++ b/experiments/sock-shop-promProbe/experiment.yaml
@@ -763,7 +763,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -834,7 +834,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -903,7 +903,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -976,7 +976,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -1052,7 +1052,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'

--- a/experiments/sock-shop-promProbe/experiment.yaml
+++ b/experiments/sock-shop-promProbe/experiment.yaml
@@ -49,12 +49,705 @@ spec:
         args: ["-namespace=sock-shop","-typeName=resilient","-operation=apply","-timeout=400", "-app=sock-shop","-scope=cluster"] #for weak provide type flagName as resilient(-typeName=weak)
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-cpu-hog-2sf
+            path: /tmp/pod-cpu-hog-2sf.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects CPU consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-cpu-hog
+                  labels:
+                    name: pod-cpu-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-cpu-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## Number of CPU cores to stress
+                      - name: CPU_CORES
+                        value: "1"
+
+                      ## LOAD CPU WITH GIVEN PERCENT LOADING FOR THE CPU STRESS WORKERS.
+                      ## 0 IS EFFECTIVELY A SLEEP (NO LOAD) AND 100 IS FULL LOADING
+                      - name: CPU_LOAD
+                        value: "100"
+
+                      ## Percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-cpu-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-delete-rm5
+            path: /tmp/pod-delete-rm5.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      - name: FORCE
+                        value: "true"
+
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: ci
+          - name: pod-network-loss-x1w
+            path: /tmp/pod-network-loss-x1w.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects network packet loss on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-network-loss
+                  labels:
+                    name: pod-network-loss
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-network-loss
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      # provide lib image
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      - name: NETWORK_INTERFACE
+                        value: "eth0"
+
+                      - name: TC_IMAGE
+                        value: "gaiadocker/iproute2"
+
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "100" #in PERCENTAGE
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60" # in seconds
+
+                      # time period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      # provide the name of container runtime
+                      # for litmus LIB, it supports docker, containerd, crio
+                      # for pumba LIB, it supports docker only
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the destination ips
+                      # chaos injection will be triggered for these destination ips
+                      - name: DESTINATION_IPS
+                        value: ""
+
+                      # provide the destination hosts
+                      # chaos injection will be triggered for these destination hosts
+                      - name: DESTINATION_HOSTS
+                        value: ""
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-network-loss
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-memory-hog-49a
+            path: /tmp/pod-memory-hog-49a.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects memory consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-memory-hog
+                  labels:
+                    name: pod-memory-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-memory-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## enter the amount of memory in megabytes to be consumed by the application pod
+                      - name: MEMORY_CONSUMPTION
+                        value: "500"
+
+                      ## Number of workers to perform stress
+                      - name: NUMBER_OF_WORKERS
+                        value: "1"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                    labels:
+                      name: pod-memory-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: disk-fill-h7d
+            path: /tmp/disk-fill-h7d.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Fillup Ephemeral Storage of a Resource
+                kind: ChaosExperiment
+                metadata:
+                  name: disk-fill
+                  labels:
+                    name: disk-fill
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name disk-fill
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: FILL_PERCENTAGE
+                        value: "80"
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      # provide the data block size
+                      # supported unit is KB
+                      - name: DATA_BLOCK_SIZE
+                        value: "256"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: EPHEMERAL_STORAGE_MEBIBYTES
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      # Provide the container runtime path
+                      # Default set to docker container path
+                      - name: CONTAINER_PATH
+                        value: "/var/lib/docker/containers"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: disk-fill
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/host-path-usage: "true"
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+          - kubectl apply -f /tmp/ -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
 
     - name: pod-cpu-hog
       inputs:
@@ -70,6 +763,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -140,6 +834,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -208,6 +903,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -280,6 +976,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -336,7 +1033,7 @@ spec:
                             - name: CONTAINER_RUNTIME
                               value: 'containerd'
                             - name: SOCKET_PATH
-                              value: '/run/containerd/containerd.sock'                
+                              value: '/run/containerd/containerd.sock'
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -355,6 +1052,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'

--- a/experiments/sock-shop-promProbe/experiment_cron.yaml
+++ b/experiments/sock-shop-promProbe/experiment_cron.yaml
@@ -767,7 +767,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -838,7 +838,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -907,7 +907,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.env.appNamespace}}_catalogue"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -980,7 +980,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -1056,7 +1056,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'

--- a/experiments/sock-shop-promProbe/experiment_cron.yaml
+++ b/experiments/sock-shop-promProbe/experiment_cron.yaml
@@ -29,7 +29,7 @@ spec:
         - - name: install-chaos-faults
             template: install-chaos-faults
           - name: load-test
-            template: load-test 
+            template: load-test
         - - name: pod-cpu-hog
             template: pod-cpu-hog
         - - name: pod-delete
@@ -39,27 +39,720 @@ spec:
         - - name: pod-memory-hog
             template: pod-memory-hog
         - - name: disk-fill
-            template: disk-fill 
+            template: disk-fill
         - - name: cleanup-chaos-resources
             template: cleanup-chaos-resources
         #  - name: delete-application
         #    template: delete-application
           - name: delete-loadtest
             template: delete-loadtest
-    
+
     - name: install-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
         args: ["-namespace=sock-shop","-typeName=resilient","-operation=apply","-timeout=400", "-app=sock-shop","-scope=cluster"] #for weak provide type flagName as resilient(-typeName=weak)
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-cpu-hog-2sf
+            path: /tmp/pod-cpu-hog-2sf.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects CPU consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-cpu-hog
+                  labels:
+                    name: pod-cpu-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-cpu-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## Number of CPU cores to stress
+                      - name: CPU_CORES
+                        value: "1"
+
+                      ## LOAD CPU WITH GIVEN PERCENT LOADING FOR THE CPU STRESS WORKERS.
+                      ## 0 IS EFFECTIVELY A SLEEP (NO LOAD) AND 100 IS FULL LOADING
+                      - name: CPU_LOAD
+                        value: "100"
+
+                      ## Percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-cpu-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-delete-rm5
+            path: /tmp/pod-delete-rm5.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      - name: FORCE
+                        value: "true"
+
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: ci
+          - name: pod-network-loss-x1w
+            path: /tmp/pod-network-loss-x1w.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects network packet loss on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-network-loss
+                  labels:
+                    name: pod-network-loss
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-network-loss
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      # provide lib image
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      - name: NETWORK_INTERFACE
+                        value: "eth0"
+
+                      - name: TC_IMAGE
+                        value: "gaiadocker/iproute2"
+
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "100" #in PERCENTAGE
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60" # in seconds
+
+                      # time period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      # provide the name of container runtime
+                      # for litmus LIB, it supports docker, containerd, crio
+                      # for pumba LIB, it supports docker only
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the destination ips
+                      # chaos injection will be triggered for these destination ips
+                      - name: DESTINATION_IPS
+                        value: ""
+
+                      # provide the destination hosts
+                      # chaos injection will be triggered for these destination hosts
+                      - name: DESTINATION_HOSTS
+                        value: ""
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-network-loss
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-memory-hog-49a
+            path: /tmp/pod-memory-hog-49a.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects memory consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-memory-hog
+                  labels:
+                    name: pod-memory-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-memory-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## enter the amount of memory in megabytes to be consumed by the application pod
+                      - name: MEMORY_CONSUMPTION
+                        value: "500"
+
+                      ## Number of workers to perform stress
+                      - name: NUMBER_OF_WORKERS
+                        value: "1"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                    labels:
+                      name: pod-memory-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: disk-fill-h7d
+            path: /tmp/disk-fill-h7d.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Fillup Ephemeral Storage of a Resource
+                kind: ChaosExperiment
+                metadata:
+                  name: disk-fill
+                  labels:
+                    name: disk-fill
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name disk-fill
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: FILL_PERCENTAGE
+                        value: "80"
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      # provide the data block size
+                      # supported unit is KB
+                      - name: DATA_BLOCK_SIZE
+                        value: "256"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: EPHEMERAL_STORAGE_MEBIBYTES
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      # Provide the container runtime path
+                      # Default set to docker container path
+                      - name: CONTAINER_PATH
+                        value: "/var/lib/docker/containers"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: disk-fill
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/host-path-usage: "true"
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
-        
+          - kubectl apply -f /tmp/ -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
+
     - name: pod-cpu-hog
       inputs:
         artifacts:
@@ -74,6 +767,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -111,7 +805,7 @@ spec:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
                               value: "100"
                           mode: "Edge"
-                          runProperties:  
+                          runProperties:
                             probeTimeout: 1s
                             interval: 100ms
                             attempt: 2
@@ -125,7 +819,7 @@ spec:
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
                               value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
-        
+
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -144,6 +838,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -181,7 +876,7 @@ spec:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
                               value: "100"
                           mode: "Edge"
-                          runProperties:  
+                          runProperties:
                             probeTimeout: 1s
                             interval: 100ms
                             attempt: 2
@@ -193,7 +888,7 @@ spec:
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
                               value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"
-                            
+
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -212,6 +907,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.env.appNamespace}}_catalogue"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -252,7 +948,7 @@ spec:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
                               value: "100"
                           mode: "Edge"
-                          runProperties:  
+                          runProperties:
                             probeTimeout: 1s
                             interval: 100ms
                             attempt: 2
@@ -268,8 +964,8 @@ spec:
                               value: 'false'
       container:
         image: litmuschaos/litmus-checker:latest
-        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]        
-    
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+
     - name: pod-network-loss
       inputs:
         artifacts:
@@ -284,6 +980,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -325,26 +1022,26 @@ spec:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
                               value: "100"
                           mode: "Edge"
-                          runProperties:  
+                          runProperties:
                             probeTimeout: 1s
                             interval: 100ms
                             attempt: 2
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
-                              value: '30' 
+                              value: '30'
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
-                              value: 'containerd' 
+                              value: 'containerd'
                             - name: SOCKET_PATH
-                              value: '/run/containerd/containerd.sock'                
+                              value: '/run/containerd/containerd.sock'
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
-    
+
     - name: disk-fill
       inputs:
         artifacts:
@@ -359,6 +1056,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -399,7 +1097,7 @@ spec:
                               criteria: ">=" #supports >=,<=,>,<,==,!= comparision
                               value: "100"
                           mode: "Edge"
-                          runProperties:  
+                          runProperties:
                             probeTimeout: 1s
                             interval: 100ms
                             attempt: 2
@@ -410,7 +1108,7 @@ spec:
                             - name: TARGET_CONTAINER
                               value: ''
                             - name: TOTAL_CHAOS_DURATION
-                              value: '30'                            
+                              value: '30'
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -429,12 +1127,12 @@ spec:
       container:
         image: litmuschaos/litmus-app-deployer:latest
         args: ["-namespace=loadtest","-operation=delete", "-app=loadtest"]
-    
+
     - name: cleanup-chaos-resources
       container:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
-        args: 
-          [ 
+        args:
+          [
             "kubectl delete chaosengine pod-memory-hog-chaos  pod-cpu-hog-chaos catalogue-pod-delete-chaos pod-network-loss-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/sock-shop-promProbe/experiment_cron.yaml
+++ b/experiments/sock-shop-promProbe/experiment_cron.yaml
@@ -70,7 +70,7 @@ spec:
                     name: pod-cpu-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -195,7 +195,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-delete-rm5
             path: /tmp/pod-delete-rm5.yaml
             raw:
@@ -211,7 +211,7 @@ spec:
                     name: pod-delete
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -316,7 +316,7 @@ spec:
                       name: pod-delete
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-network-loss-x1w
             path: /tmp/pod-network-loss-x1w.yaml
             raw:
@@ -332,7 +332,7 @@ spec:
                     name: pod-network-loss
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -465,7 +465,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-memory-hog-49a
             path: /tmp/pod-memory-hog-49a.yaml
             raw:
@@ -481,7 +481,7 @@ spec:
                     name: pod-memory-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -605,7 +605,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: disk-fill-h7d
             path: /tmp/disk-fill-h7d.yaml
             raw:
@@ -621,7 +621,7 @@ spec:
                     name: disk-fill
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -740,7 +740,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/host-path-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/sock-shop/experiment.yaml
+++ b/experiments/sock-shop/experiment.yaml
@@ -66,7 +66,7 @@ spec:
                     name: pod-cpu-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -191,7 +191,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-delete-rm5
             path: /tmp/pod-delete-rm5.yaml
             raw:
@@ -207,7 +207,7 @@ spec:
                     name: pod-delete
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -312,7 +312,7 @@ spec:
                       name: pod-delete
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-network-loss-x1w
             path: /tmp/pod-network-loss-x1w.yaml
             raw:
@@ -328,7 +328,7 @@ spec:
                     name: pod-network-loss
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -461,7 +461,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-memory-hog-49a
             path: /tmp/pod-memory-hog-49a.yaml
             raw:
@@ -477,7 +477,7 @@ spec:
                     name: pod-memory-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -601,7 +601,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: disk-fill-h7d
             path: /tmp/disk-fill-h7d.yaml
             raw:
@@ -617,7 +617,7 @@ spec:
                     name: disk-fill
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -736,7 +736,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/host-path-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:

--- a/experiments/sock-shop/experiment.yaml
+++ b/experiments/sock-shop/experiment.yaml
@@ -763,7 +763,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -835,7 +835,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -905,7 +905,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -979,7 +979,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -1055,7 +1055,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'

--- a/experiments/sock-shop/experiment.yaml
+++ b/experiments/sock-shop/experiment.yaml
@@ -35,7 +35,7 @@ spec:
         - - name: pod-memory-hog
             template: pod-memory-hog
         - - name: disk-fill
-            template: disk-fill   
+            template: disk-fill
         - - name: cleanup-chaos-resources
             template: cleanup-chaos-resources
         #  - name: delete-application
@@ -49,12 +49,705 @@ spec:
         args: ["-namespace=sock-shop","-typeName=resilient","-operation=apply","-timeout=400", "-app=sock-shop","-scope=cluster"] #for weak provide type flagName as resilient(-typeName=weak)
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-cpu-hog-2sf
+            path: /tmp/pod-cpu-hog-2sf.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects CPU consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-cpu-hog
+                  labels:
+                    name: pod-cpu-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-cpu-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## Number of CPU cores to stress
+                      - name: CPU_CORES
+                        value: "1"
+
+                      ## LOAD CPU WITH GIVEN PERCENT LOADING FOR THE CPU STRESS WORKERS.
+                      ## 0 IS EFFECTIVELY A SLEEP (NO LOAD) AND 100 IS FULL LOADING
+                      - name: CPU_LOAD
+                        value: "100"
+
+                      ## Percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-cpu-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-delete-rm5
+            path: /tmp/pod-delete-rm5.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      - name: FORCE
+                        value: "true"
+
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: ci
+          - name: pod-network-loss-x1w
+            path: /tmp/pod-network-loss-x1w.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects network packet loss on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-network-loss
+                  labels:
+                    name: pod-network-loss
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-network-loss
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      # provide lib image
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      - name: NETWORK_INTERFACE
+                        value: "eth0"
+
+                      - name: TC_IMAGE
+                        value: "gaiadocker/iproute2"
+
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "100" #in PERCENTAGE
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60" # in seconds
+
+                      # time period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      # provide the name of container runtime
+                      # for litmus LIB, it supports docker, containerd, crio
+                      # for pumba LIB, it supports docker only
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the destination ips
+                      # chaos injection will be triggered for these destination ips
+                      - name: DESTINATION_IPS
+                        value: ""
+
+                      # provide the destination hosts
+                      # chaos injection will be triggered for these destination hosts
+                      - name: DESTINATION_HOSTS
+                        value: ""
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-network-loss
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-memory-hog-49a
+            path: /tmp/pod-memory-hog-49a.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects memory consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-memory-hog
+                  labels:
+                    name: pod-memory-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-memory-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## enter the amount of memory in megabytes to be consumed by the application pod
+                      - name: MEMORY_CONSUMPTION
+                        value: "500"
+
+                      ## Number of workers to perform stress
+                      - name: NUMBER_OF_WORKERS
+                        value: "1"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                    labels:
+                      name: pod-memory-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: disk-fill-h7d
+            path: /tmp/disk-fill-h7d.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Fillup Ephemeral Storage of a Resource
+                kind: ChaosExperiment
+                metadata:
+                  name: disk-fill
+                  labels:
+                    name: disk-fill
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name disk-fill
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: FILL_PERCENTAGE
+                        value: "80"
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      # provide the data block size
+                      # supported unit is KB
+                      - name: DATA_BLOCK_SIZE
+                        value: "256"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: EPHEMERAL_STORAGE_MEBIBYTES
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      # Provide the container runtime path
+                      # Default set to docker container path
+                      - name: CONTAINER_PATH
+                        value: "/var/lib/docker/containers"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: disk-fill
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/host-path-usage: "true"
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+          - kubectl apply -f /tmp/ -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
 
     - name: pod-cpu-hog
       inputs:
@@ -70,6 +763,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -122,7 +816,7 @@ spec:
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
                               value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
-        
+
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -141,6 +835,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -191,7 +886,7 @@ spec:
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
                               value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"
-                            
+
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -210,6 +905,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -267,8 +963,8 @@ spec:
                               value: 'false'
       container:
         image: litmuschaos/litmus-checker:latest
-        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]        
-    
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+
     - name: pod-network-loss
       inputs:
         artifacts:
@@ -283,6 +979,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -358,6 +1055,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'

--- a/experiments/sock-shop/experiment_cron.yaml
+++ b/experiments/sock-shop/experiment_cron.yaml
@@ -29,7 +29,7 @@ spec:
         - - name: install-chaos-faults
             template: install-chaos-faults
           - name: load-test
-            template: load-test  
+            template: load-test
         - - name: pod-cpu-hog
             template: pod-cpu-hog
         - - name: pod-delete
@@ -39,7 +39,7 @@ spec:
         - - name: pod-memory-hog
             template: pod-memory-hog
         - - name: disk-fill
-            template: disk-fill  
+            template: disk-fill
         - - name: cleanup-chaos-resources
             template: cleanup-chaos-resources
         #  - name: delete-application
@@ -53,12 +53,705 @@ spec:
         args: ["-namespace=sock-shop","-typeName=resilient","-operation=apply","-timeout=400", "-app=sock-shop","-scope=cluster"] #for weak provide type flagName as resilient(-typeName=weak)
 
     - name: install-chaos-faults
+      inputs:
+        artifacts:
+          - name: pod-cpu-hog-2sf
+            path: /tmp/pod-cpu-hog-2sf.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects CPU consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-cpu-hog
+                  labels:
+                    name: pod-cpu-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-cpu-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## Number of CPU cores to stress
+                      - name: CPU_CORES
+                        value: "1"
+
+                      ## LOAD CPU WITH GIVEN PERCENT LOADING FOR THE CPU STRESS WORKERS.
+                      ## 0 IS EFFECTIVELY A SLEEP (NO LOAD) AND 100 IS FULL LOADING
+                      - name: CPU_LOAD
+                        value: "100"
+
+                      ## Percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-cpu-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-delete-rm5
+            path: /tmp/pod-delete-rm5.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      - name: FORCE
+                        value: "true"
+
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: ci
+          - name: pod-network-loss-x1w
+            path: /tmp/pod-network-loss-x1w.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects network packet loss on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-network-loss
+                  labels:
+                    name: pod-network-loss
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-network-loss
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      # provide lib image
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      - name: NETWORK_INTERFACE
+                        value: "eth0"
+
+                      - name: TC_IMAGE
+                        value: "gaiadocker/iproute2"
+
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "100" #in PERCENTAGE
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60" # in seconds
+
+                      # time period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      # provide the name of container runtime
+                      # for litmus LIB, it supports docker, containerd, crio
+                      # for pumba LIB, it supports docker only
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the destination ips
+                      # chaos injection will be triggered for these destination ips
+                      - name: DESTINATION_IPS
+                        value: ""
+
+                      # provide the destination hosts
+                      # chaos injection will be triggered for these destination hosts
+                      - name: DESTINATION_HOSTS
+                        value: ""
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: pod-network-loss
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: pod-memory-hog-49a
+            path: /tmp/pod-memory-hog-49a.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Injects memory consumption on pods belonging to an app deployment
+                kind: ChaosExperiment
+                metadata:
+                  name: pod-memory-hog
+                  labels:
+                    name: pod-memory-hog
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-memory-hog
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      ## enter the amount of memory in megabytes to be consumed by the application pod
+                      - name: MEMORY_CONSUMPTION
+                        value: "500"
+
+                      ## Number of workers to perform stress
+                      - name: NUMBER_OF_WORKERS
+                        value: "1"
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      ## Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      ## It is used in pumba lib only
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      ## It is used in pumba lib only
+                      - name: STRESS_IMAGE
+                        value: "alexeiled/stress-ng:latest-ubuntu"
+
+                      ## provide the cluster runtime
+                      - name: CONTAINER_RUNTIME
+                        value: "containerd"
+
+                      # provide the socket file path
+                      - name: SOCKET_PATH
+                        value: "/run/containerd/containerd.sock"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                    labels:
+                      name: pod-memory-hog
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/runtime-api-usage: "true"
+                      app.kubernetes.io/version: ci
+          - name: disk-fill-h7d
+            path: /tmp/disk-fill-h7d.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                description:
+                  message: |
+                    Fillup Ephemeral Storage of a Resource
+                kind: ChaosExperiment
+                metadata:
+                  name: disk-fill
+                  labels:
+                    name: disk-fill
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: ci
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      # Create and monitor the experiment & helper pods
+                      - apiGroups: [""]
+                        resources: ["pods"]
+                        verbs:
+                          [
+                            "create",
+                            "delete",
+                            "get",
+                            "list",
+                            "patch",
+                            "update",
+                            "deletecollection",
+                          ]
+                      # Performs CRUD operations on the events inside chaosengine and chaosresult
+                      - apiGroups: [""]
+                        resources: ["events"]
+                        verbs: ["create", "get", "list", "patch", "update"]
+                      # Fetch configmaps details and mount it to the experiment pod (if specified)
+                      - apiGroups: [""]
+                        resources: ["configmaps"]
+                        verbs: ["get", "list"]
+                      # Track and get the runner, experiment, and helper pods log
+                      - apiGroups: [""]
+                        resources: ["pods/log"]
+                        verbs: ["get", "list", "watch"]
+                      # for creating and managing to execute commands inside target container
+                      - apiGroups: [""]
+                        resources: ["pods/exec"]
+                        verbs: ["get", "list", "create"]
+                      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+                      - apiGroups: ["apps"]
+                        resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: ["apps.openshift.io"]
+                        resources: ["deploymentconfigs"]
+                        verbs: ["list", "get"]
+                      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+                      - apiGroups: [""]
+                        resources: ["replicationcontrollers"]
+                        verbs: ["get", "list"]
+                      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+                      - apiGroups: ["argoproj.io"]
+                        resources: ["rollouts"]
+                        verbs: ["list", "get"]
+                      # for configuring and monitor the experiment job by the chaos-runner pod
+                      - apiGroups: ["batch"]
+                        resources: ["jobs"]
+                        verbs: ["create", "list", "get", "delete", "deletecollection"]
+                      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+                      - apiGroups: ["litmuschaos.io"]
+                        resources: ["chaosengines", "chaosexperiments", "chaosresults"]
+                        verbs: ["create", "list", "get", "patch", "update", "delete"]
+                    image: "litmuschaos/go-runner:latest"
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name disk-fill
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TARGET_CONTAINER
+                        value: ""
+
+                      - name: FILL_PERCENTAGE
+                        value: "80"
+
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "60"
+
+                      # Period to wait before and after injection of chaos in sec
+                      - name: RAMP_TIME
+                        value: ""
+
+                      # provide the data block size
+                      # supported unit is KB
+                      - name: DATA_BLOCK_SIZE
+                        value: "256"
+
+                      - name: TARGET_PODS
+                        value: ""
+
+                      - name: EPHEMERAL_STORAGE_MEBIBYTES
+                        value: ""
+
+                      # To select pods on specific node(s)
+                      - name: NODE_LABEL
+                        value: ""
+
+                      ## percentage of total pods to target
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+
+                      - name: DEFAULT_HEALTH_CHECK
+                        value: "false"
+
+                      - name: LIB_IMAGE
+                        value: "litmuschaos/go-runner:latest"
+
+                      # Provide the container runtime path
+                      # Default set to docker container path
+                      - name: CONTAINER_PATH
+                        value: "/var/lib/docker/containers"
+
+                      ## it defines the sequence of chaos execution for multiple target pods
+                      ## supported values: serial, parallel
+                      - name: SEQUENCE
+                        value: "parallel"
+
+                    labels:
+                      name: disk-fill
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/host-path-usage: "true"
+                      app.kubernetes.io/version: ci
+      outputs: {}
+      metadata: {}
       container:
+        name: ""
         image: litmuschaos/k8s:latest
-        command: [sh, -c]
+        command:
+          - sh
+          - "-c"
         args:
-          - "kubectl apply -f https://hub.litmuschaos.io/api/chaos/master?file=faults/kubernetes/experiments.yaml -n
-            {{workflow.parameters.adminModeNamespace}} ; sleep 30"
+          - kubectl apply -f /tmp/ -n {{workflow.parameters.adminModeNamespace}} && sleep 30
+        resources: {}
 
     - name: pod-cpu-hog
       inputs:
@@ -74,6 +767,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -126,7 +820,7 @@ spec:
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
                               value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
-        
+
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -145,6 +839,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -195,7 +890,7 @@ spec:
                               value: '30' # in seconds
                             - name: CHAOS_KILL_COMMAND
                               value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"
-                            
+
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -214,6 +909,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -271,8 +967,8 @@ spec:
                               value: 'false'
       container:
         image: litmuschaos/litmus-checker:latest
-        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]        
-    
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+
     - name: pod-network-loss
       inputs:
         artifacts:
@@ -287,6 +983,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -335,18 +1032,18 @@ spec:
                         components:
                           env:
                             - name: TOTAL_CHAOS_DURATION
-                              value: '30' 
+                              value: '30'
                             - name: NETWORK_INTERFACE
                               value: 'eth0'
                             - name: NETWORK_PACKET_LOSS_PERCENTAGE
                               value: '100'
                             - name: CONTAINER_RUNTIME
-                              value: 'containerd' 
+                              value: 'containerd'
                             - name: SOCKET_PATH
-                              value: '/run/containerd/containerd.sock'                
+                              value: '/run/containerd/containerd.sock'
       container:
         image: litmuschaos/litmus-checker:latest
-        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"] 
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
 
     - name: disk-fill
       inputs:
@@ -362,6 +1059,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
+                  annotation: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -414,7 +1112,7 @@ spec:
                             - name: TARGET_CONTAINER
                               value: ''
                             - name: TOTAL_CHAOS_DURATION
-                              value: '30'                            
+                              value: '30'
       container:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
@@ -432,13 +1130,13 @@ spec:
     - name: delete-loadtest
       container:
         image: litmuschaos/litmus-app-deployer:latest
-        args: ["-namespace=loadtest","-operation=delete", "-app=loadtest"]    
-    
+        args: ["-namespace=loadtest","-operation=delete", "-app=loadtest"]
+
     - name: cleanup-chaos-resources
       container:
         image: litmuschaos/k8s:latest
         command: [sh, -c]
-        args: 
-          [ 
+        args:
+          [
             "kubectl delete chaosengine pod-memory-hog-chaos pod-cpu-hog-chaos catalogue-pod-delete-chaos pod-network-loss-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/sock-shop/experiment_cron.yaml
+++ b/experiments/sock-shop/experiment_cron.yaml
@@ -767,7 +767,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_carts"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -839,7 +839,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_orders"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -909,7 +909,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -983,7 +983,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_user-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'
@@ -1059,7 +1059,7 @@ spec:
                   namespace: {{workflow.parameters.adminModeNamespace}}
                   labels:
                     context: "{{workflow.parameters.appNamespace}}_catalogue-db"
-                  annotation: {}
+                  annotations: {}
                 spec:
                   appinfo:
                     appns: 'sock-shop'

--- a/experiments/sock-shop/experiment_cron.yaml
+++ b/experiments/sock-shop/experiment_cron.yaml
@@ -70,7 +70,7 @@ spec:
                     name: pod-cpu-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -195,7 +195,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-delete-rm5
             path: /tmp/pod-delete-rm5.yaml
             raw:
@@ -211,7 +211,7 @@ spec:
                     name: pod-delete
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -316,7 +316,7 @@ spec:
                       name: pod-delete
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-network-loss-x1w
             path: /tmp/pod-network-loss-x1w.yaml
             raw:
@@ -332,7 +332,7 @@ spec:
                     name: pod-network-loss
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -465,7 +465,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: pod-memory-hog-49a
             path: /tmp/pod-memory-hog-49a.yaml
             raw:
@@ -481,7 +481,7 @@ spec:
                     name: pod-memory-hog
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -605,7 +605,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/runtime-api-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
           - name: disk-fill-h7d
             path: /tmp/disk-fill-h7d.yaml
             raw:
@@ -621,7 +621,7 @@ spec:
                     name: disk-fill
                     app.kubernetes.io/part-of: litmus
                     app.kubernetes.io/component: chaosexperiment
-                    app.kubernetes.io/version: ci
+                    app.kubernetes.io/version: latest
                 spec:
                   definition:
                     scope: Namespaced
@@ -740,7 +740,7 @@ spec:
                       app.kubernetes.io/part-of: litmus
                       app.kubernetes.io/component: experiment-job
                       app.kubernetes.io/host-path-usage: "true"
-                      app.kubernetes.io/version: ci
+                      app.kubernetes.io/version: latest
       outputs: {}
       metadata: {}
       container:


### PR DESCRIPTION
- Adds `metadata.annotation` in ChaosEngine
- Replaces `install-chaos-faults` step to use `artifacts.data.raw` manifests