### PR TITLE
fix: update k6 engine for deleting 'Target Application' tab

### DIFF
--- a/faults/load/k6-loadgen/engine.yaml
+++ b/faults/load/k6-loadgen/engine.yaml
@@ -6,10 +6,6 @@ metadata:
   namespace: default
 spec:
   engineState: 'active'
-  appinfo:
-    appns: ''
-    applabel: ''
-    appkind: ''
   chaosServiceAccount: litmus-admin
   experiments:
     - name: k6-loadgen


### PR DESCRIPTION
I deleted `appinfo` attributes for deleting 'Target Application' tab.

`before`
<img width="1512" alt="Screenshot 2024-08-06 at 8 43 07 PM" src="https://github.com/user-attachments/assets/c9cf07ea-3ab6-4bf6-939f-5e6a7345e4e2">

`after`
<img width="1512" alt="Screenshot 2024-08-06 at 8 43 16 PM" src="https://github.com/user-attachments/assets/df4675dd-4b07-4568-9748-13e32350bd5d">

