### PR TITLE
chore: remove unused variables in the k6 chaos fault

### DIFF
--- a/faults/load/experiments.yaml
+++ b/faults/load/experiments.yaml
@@ -64,10 +64,6 @@ spec:
       - name: TOTAL_CHAOS_DURATION
         value: "30"
 
-      # Interval between chaos injection in sec
-      - name: CHAOS_INTERVAL
-        value: "30"
-
       # Period to wait before and after injection of chaos in sec
       - name: RAMP_TIME
         value: "0"

--- a/faults/load/k6-loadgen/engine.yaml
+++ b/faults/load/k6-loadgen/engine.yaml
@@ -16,10 +16,6 @@ spec:
             - name: TOTAL_CHAOS_DURATION
               value: "30"
 
-            # Interval between chaos injection in sec
-            - name: CHAOS_INTERVAL
-              value: "30"
-
             # Period to wait before and after injection of chaos in sec
             - name: RAMP_TIME
               value: "0"

--- a/faults/load/k6-loadgen/fault.yaml
+++ b/faults/load/k6-loadgen/fault.yaml
@@ -64,10 +64,6 @@ spec:
       - name: TOTAL_CHAOS_DURATION
         value: "30"
 
-      # Interval between chaos injection in sec
-      - name: CHAOS_INTERVAL
-        value: "30"
-
       # Period to wait before and after injection of chaos in sec
       - name: RAMP_TIME
         value: "0"


### PR DESCRIPTION
I deleted chaos_interval variable because of not usedI deleted the `chaos_interval` variable because it was not being used.


relevant: https://github.com/litmuschaos/litmus-go/pull/725