### PR TITLE
feat: export k6 results output to the OTEL collector

### DIFF
--- a/faults/load/experiments.yaml
+++ b/faults/load/experiments.yaml
@@ -88,6 +88,10 @@ spec:
       - name: LIB_IMAGE_PULL_POLICY
         value: "Always"
 
+      # Provide the prefix of the metric if you enabled observability
+      - name: OTEL_METRIC_PREFIX
+        value: "k6_"
+
     labels:
       name: k6-loadgen
       app.kubernetes.io/part-of: litmus

--- a/faults/load/k6-loadgen/engine.yaml
+++ b/faults/load/k6-loadgen/engine.yaml
@@ -39,3 +39,7 @@ spec:
             # Provide the image pull policy of the helper pod
             - name: LIB_IMAGE_PULL_POLICY
               value: "Always"
+
+            # Provide the prefix of the metric if you enabled observability
+            - name: OTEL_METRIC_PREFIX
+              value: "k6_"

--- a/faults/load/k6-loadgen/fault.yaml
+++ b/faults/load/k6-loadgen/fault.yaml
@@ -88,6 +88,9 @@ spec:
       - name: LIB_IMAGE_PULL_POLICY
         value: "Always"
 
+      # Provide the prefix of the metric if you enabled observability
+      - name: OTEL_METRIC_PREFIX
+        value: "k6_"
     labels:
       name: k6-loadgen
       app.kubernetes.io/part-of: litmus


### PR DESCRIPTION
I added a env named `OTEL_METRIC_PREFIX`. This pr has a dependency with https://github.com/litmuschaos/litmus-go/pull/726.