### PR TITLE
feat(aws-az-chaos): add new environment variable LOAD_BALANCER_VERSIO…

### DIFF
--- a/faults/aws/aws-az-chaos/engine.yaml
+++ b/faults/aws/aws-az-chaos/engine.yaml
@@ -26,3 +26,5 @@ spec:
               value: "na"
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: "/tmp/cloud_config.yml"
+            - name: LOAD_BALANCER_VERSION
+              value: 'elbv2

--- a/faults/aws/aws-az-chaos/fault.yaml
+++ b/faults/aws/aws-az-chaos/fault.yaml
@@ -67,6 +67,9 @@ spec:
         value: "/tmp/cloud_config.yml"
       - name: RAMP_TIME
         value: ''
+      - name: LOAD_BALANCER_VERSION
+        value: 'elbv2
+    resources:
     labels:
       name: aws-az-chaos
       app.kubernetes.io/part-of: litmus


### PR DESCRIPTION
Add new environment variable LOAD_BALANCER_VERSION to aws-az-chaos fault for AWS Load Balancers.

Linked to this [PR](https://github.com/litmuschaos/litmus-python/pull/54) in litmus-python that allows to perform zone failure for elbv2.