### PR TITLE
fix: replace hardcoded kube-proxy target with workflow parameters

### DIFF
--- a/experiments/node-cpu-hog/experiment.yaml
+++ b/experiments/node-cpu-hog/experiment.yaml
@@ -117,7 +117,7 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: kube-proxy-node-cpu-hog-chaos
+                  name: node-cpu-hog-chaos
                   namespace: "{{workflow.parameters.adminModeNamespace}}"
                   labels:
                     context: "{{workflow.parameters.context}}"
@@ -146,5 +146,5 @@ spec:
         command: [sh, -c]
         args:
           [
-            "kubectl delete chaosengine kube-proxy-node-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine node-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/node-cpu-hog/experiment_cron.yaml
+++ b/experiments/node-cpu-hog/experiment_cron.yaml
@@ -121,7 +121,7 @@ spec:
                   apiVersion: litmuschaos.io/v1alpha1
                   kind: ChaosEngine
                   metadata:
-                    name: kube-proxy-node-cpu-hog-chaos
+                    name: node-cpu-hog-chaos
                     namespace: "{{workflow.parameters.adminModeNamespace}}"
                     labels:
                       context: "{{workflow.parameters.context}}"
@@ -150,5 +150,5 @@ spec:
           command: [sh, -c]
           args:
             [
-              "kubectl delete chaosengine kube-proxy-node-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+              "kubectl delete chaosengine node-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
             ]

--- a/experiments/node-memory-hog/experiment.yaml
+++ b/experiments/node-memory-hog/experiment.yaml
@@ -117,7 +117,7 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: kube-proxy-node-memory-hog-chaos
+                  name: node-memory-hog-chaos
                   namespace: "{{workflow.parameters.adminModeNamespace}}"
                   labels:
                     context: "{{workflow.parameters.context}}"
@@ -146,5 +146,5 @@ spec:
         command: [sh, -c]
         args:
           [
-            "kubectl delete chaosengine kube-proxy-node-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine node-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/node-memory-hog/experiment_cron.yaml
+++ b/experiments/node-memory-hog/experiment_cron.yaml
@@ -114,7 +114,7 @@ spec:
                   apiVersion: litmuschaos.io/v1alpha1
                   kind: ChaosEngine
                   metadata:
-                    name: kube-proxy-node-memory-hog-chaos
+                    name: node-memory-hog-chaos
                     namespace: "{{workflow.parameters.adminModeNamespace}}"
                     labels:
                       context: "{{workflow.parameters.context}}"
@@ -141,5 +141,5 @@ spec:
           command: [sh, -c]
           args:
             [
-              "kubectl delete chaosengine kube-proxy-node-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+              "kubectl delete chaosengine node-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
             ]

--- a/experiments/pod-cpu-hog/experiment.yaml
+++ b/experiments/pod-cpu-hog/experiment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argowf-chaos-pod-cpu-hog
   namespace: litmus
   labels:
-    subject: "{{workflow.parameters.appNamespace}}_kube-proxy"
+    subject: "{{workflow.parameters.appNamespace}}_pod-cpu-hog"
 spec:
   entrypoint: argowf-chaos
   serviceAccountName: argo-chaos
@@ -16,7 +16,11 @@ spec:
       - name: adminModeNamespace
         value: "litmus"
       - name: appNamespace
-        value: "kube-system"
+        value: "default"
+      - name: appLabel
+        value: "app=my-app"
+      - name: appKind
+        value: "deployment"
   templates:
     - name: argowf-chaos
       steps:
@@ -113,16 +117,16 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: kube-proxy-pod-cpu-hog-chaos
+                  name: pod-cpu-hog-chaos
                   namespace: "{{workflow.parameters.adminModeNamespace}}"
                   labels:
-                    context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                    context: "{{workflow.parameters.appNamespace}}_pod-cpu-hog"
                   annotations: {}
                 spec:
                   appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
+                    appns: "{{workflow.parameters.appNamespace}}"
+                    applabel: "{{workflow.parameters.appLabel}}"
+                    appkind: "{{workflow.parameters.appKind}}"
                   jobCleanUpPolicy: retain
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -132,7 +136,7 @@ spec:
                         components:
                           env:
                             - name: TARGET_CONTAINER
-                              value: 'kube-proxy'
+                              value: ''
 
                             - name: CPU_CORES
                               value: '1'
@@ -152,5 +156,5 @@ spec:
         command: [sh, -c]
         args:
           [
-            "kubectl delete chaosengine kube-proxy-pod-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine pod-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/pod-cpu-hog/experiment_cron.yaml
+++ b/experiments/pod-cpu-hog/experiment_cron.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argo-chaos-pod-cpu-cron-wf
   namespace: litmus
   labels:
-    subject: "{{workflow.parameters.appNamespace}}_kube-proxy"
+    subject: "{{workflow.parameters.appNamespace}}_pod-cpu-hog"
 spec:
   schedule: "0 * * * *"
   concurrencyPolicy: "Forbid"
@@ -20,7 +20,11 @@ spec:
         - name: adminModeNamespace
           value: "litmus"
         - name: appNamespace
-          value: "kube-system"
+          value: "default"
+        - name: appLabel
+          value: "app=my-app"
+        - name: appKind
+          value: "deployment"
     templates:
       - name: argowf-chaos
         steps:
@@ -117,16 +121,16 @@ spec:
                   apiVersion: litmuschaos.io/v1alpha1
                   kind: ChaosEngine
                   metadata:
-                    name: kube-proxy-pod-cpu-hog-chaos
+                    name: pod-cpu-hog-chaos
                     namespace: "{{workflow.parameters.adminModeNamespace}}"
                     labels:
-                      context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                      context: "{{workflow.parameters.appNamespace}}_pod-cpu-hog"
                     annotations: {}
                   spec:
                     appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
+                      appns: "{{workflow.parameters.appNamespace}}"
+                      applabel: "{{workflow.parameters.appLabel}}"
+                      appkind: "{{workflow.parameters.appKind}}"
                     jobCleanUpPolicy: retain
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -136,7 +140,7 @@ spec:
                           components:
                             env:
                               - name: TARGET_CONTAINER
-                                value: 'kube-proxy'
+                                value: ''
 
                               - name: CPU_CORES
                                 value: '1'
@@ -156,5 +160,5 @@ spec:
           command: [sh, -c]
           args:
             [
-              "kubectl delete chaosengine kube-proxy-pod-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+              "kubectl delete chaosengine pod-cpu-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
             ]

--- a/experiments/pod-delete/experiment.yaml
+++ b/experiments/pod-delete/experiment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argowf-chaos-pod-delete
   namespace: litmus
   labels:
-    subject: "{{workflow.parameters.appNamespace}}_kube-proxy"
+    subject: "{{workflow.parameters.appNamespace}}_pod-delete"
 spec:
   entrypoint: argowf-chaos
   serviceAccountName: argo-chaos
@@ -16,7 +16,11 @@ spec:
       - name: adminModeNamespace
         value: "litmus"
       - name: appNamespace
-        value: "kube-system"
+        value: "default"
+      - name: appLabel
+        value: "app=my-app"
+      - name: appKind
+        value: "deployment"
   templates:
     - name: argowf-chaos
       steps:
@@ -120,16 +124,16 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: kube-proxy-pod-delete-chaos
+                  name: pod-delete-chaos
                   namespace: "{{workflow.parameters.adminModeNamespace}}"
                   labels:
-                    context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                    context: "{{workflow.parameters.appNamespace}}_pod-delete"
                   annotations: {}
                 spec:
                   appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
+                    appns: "{{workflow.parameters.appNamespace}}"
+                    applabel: "{{workflow.parameters.appLabel}}"
+                    appkind: "{{workflow.parameters.appKind}}"
                   jobCleanUpPolicy: retain
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -154,5 +158,5 @@ spec:
         command: [sh, -c]
         args:
           [
-            "kubectl delete chaosengine kube-proxy-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/pod-delete/experiment_cron.yaml
+++ b/experiments/pod-delete/experiment_cron.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argo-chaos-pod-delete-cron-wf
   namespace: litmus
   labels:
-    subject: "{{workflow.parameters.appNamespace}}_kube-proxy"
+    subject: "{{workflow.parameters.appNamespace}}_pod-delete"
 spec:
   schedule: "0 * * * *"
   concurrencyPolicy: "Forbid"
@@ -20,7 +20,11 @@ spec:
         - name: adminModeNamespace
           value: "litmus"
         - name: appNamespace
-          value: "kube-system"
+          value: "default"
+        - name: appLabel
+          value: "app=my-app"
+        - name: appKind
+          value: "deployment"
     templates:
       - name: argowf-chaos
         steps:
@@ -124,16 +128,16 @@ spec:
                   apiVersion: litmuschaos.io/v1alpha1
                   kind: ChaosEngine
                   metadata:
-                    name: kube-proxy-pod-delete-chaos
+                    name: pod-delete-chaos
                     namespace: "{{workflow.parameters.adminModeNamespace}}"
                     labels:
-                      context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                      context: "{{workflow.parameters.appNamespace}}_pod-delete"
                     annotations: {}
                   spec:
                     appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
+                      appns: "{{workflow.parameters.appNamespace}}"
+                      applabel: "{{workflow.parameters.appLabel}}"
+                      appkind: "{{workflow.parameters.appKind}}"
                     jobCleanUpPolicy: retain
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -158,5 +162,5 @@ spec:
           command: [sh, -c]
           args:
             [
-              "kubectl delete chaosengine kube-proxy-pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
+              "kubectl delete chaosengine pod-delete-chaos -n {{workflow.parameters.adminModeNamespace}}",
             ]

--- a/experiments/pod-memory-hog/experiment.yaml
+++ b/experiments/pod-memory-hog/experiment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argowf-chaos-pod-memory-hog
   namespace: litmus
   labels:
-    subject: "{{workflow.parameters.appNamespace}}_kube-proxy"
+    subject: "{{workflow.parameters.appNamespace}}_pod-memory-hog"
 spec:
   entrypoint: argowf-chaos
   serviceAccountName: argo-chaos
@@ -16,7 +16,11 @@ spec:
       - name: adminModeNamespace
         value: "litmus"
       - name: appNamespace
-        value: "kube-system"
+        value: "default"
+      - name: appLabel
+        value: "app=my-app"
+      - name: appKind
+        value: "deployment"
   templates:
     - name: argowf-chaos
       steps:
@@ -112,16 +116,16 @@ spec:
                 apiVersion: litmuschaos.io/v1alpha1
                 kind: ChaosEngine
                 metadata:
-                  name: kube-proxy-pod-memory-hog-chaos
+                  name: pod-memory-hog-chaos
                   namespace: "{{workflow.parameters.adminModeNamespace}}"
                   labels:
-                    context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                    context: "{{workflow.parameters.appNamespace}}_pod-memory-hog"
                   annotations: {}
                 spec:
                   appinfo:
-                    appns: kube-system
-                    applabel: "k8s-app=kube-proxy"
-                    appkind: daemonset
+                    appns: "{{workflow.parameters.appNamespace}}"
+                    applabel: "{{workflow.parameters.appLabel}}"
+                    appkind: "{{workflow.parameters.appKind}}"
                   jobCleanUpPolicy: retain
                   engineState: 'active'
                   chaosServiceAccount: litmus-admin
@@ -131,7 +135,7 @@ spec:
                         components:
                           env:
                             - name: TARGET_CONTAINER
-                              value: 'kube-proxy'
+                              value: ''
 
                             - name: MEMORY_CONSUMPTION
                               value: '500'
@@ -151,5 +155,5 @@ spec:
         command: [sh, -c]
         args:
           [
-            "kubectl delete chaosengine kube-proxy-pod-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+            "kubectl delete chaosengine pod-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
           ]

--- a/experiments/pod-memory-hog/experiment_cron.yaml
+++ b/experiments/pod-memory-hog/experiment_cron.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argo-chaos-pod-memory-cron-wf
   namespace: litmus
   labels:
-    subject: "{{workflow.parameters.appNamespace}}_kube-proxy"
+    subject: "{{workflow.parameters.appNamespace}}_pod-memory-hog"
 spec:
   schedule: "0 * * * *"
   concurrencyPolicy: "Forbid"
@@ -20,7 +20,11 @@ spec:
         - name: adminModeNamespace
           value: "litmus"
         - name: appNamespace
-          value: "kube-system"
+          value: "default"
+        - name: appLabel
+          value: "app=my-app"
+        - name: appKind
+          value: "deployment"
     templates:
       - name: argowf-chaos
         steps:
@@ -116,16 +120,16 @@ spec:
                   apiVersion: litmuschaos.io/v1alpha1
                   kind: ChaosEngine
                   metadata:
-                    name: kube-proxy-pod-memory-hog-chaos
+                    name: pod-memory-hog-chaos
                     namespace: "{{workflow.parameters.adminModeNamespace}}"
                     labels:
-                      context: "{{workflow.parameters.appNamespace}}_kube-proxy"
+                      context: "{{workflow.parameters.appNamespace}}_pod-memory-hog"
                     annotations: {}
                   spec:
                     appinfo:
-                      appns: kube-system
-                      applabel: "k8s-app=kube-proxy"
-                      appkind: daemonset
+                      appns: "{{workflow.parameters.appNamespace}}"
+                      applabel: "{{workflow.parameters.appLabel}}"
+                      appkind: "{{workflow.parameters.appKind}}"
                     jobCleanUpPolicy: retain
                     engineState: 'active'
                     chaosServiceAccount: litmus-admin
@@ -135,7 +139,7 @@ spec:
                           components:
                             env:
                               - name: TARGET_CONTAINER
-                                value: 'kube-proxy'
+                                value: ''
 
                               - name: MEMORY_CONSUMPTION
                                 value: '500'
@@ -155,5 +159,5 @@ spec:
           command: [sh, -c]
           args:
             [
-              "kubectl delete chaosengine kube-proxy-pod-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
+              "kubectl delete chaosengine pod-memory-hog-chaos -n {{workflow.parameters.adminModeNamespace}}",
             ]


### PR DESCRIPTION
## Summary

- All experiment templates had `kube-proxy` hardcoded as the target application, making the wizard confusing (it showed `kube-proxy` regardless of user input)
- Replaced hardcoded references with the experiment name in labels and parameterized the app target via workflow parameters (`appLabel`, `appKind`)

### Changes across 10 files (5 experiments x 2 variants each)

**Pod experiments** (pod-delete, pod-cpu-hog, pod-memory-hog):
- `subject`/`context` labels: `_kube-proxy` → `_<experiment-name>`
- Added `appLabel` (default: `app=my-app`) and `appKind` (default: `deployment`) workflow parameters
- Parameterized `appinfo` in ChaosEngine: `appns`, `applabel`, `appkind` now use workflow parameters
- Cleared `TARGET_CONTAINER` default (was `kube-proxy`)
- ChaosEngine name: `kube-proxy-<experiment>-chaos` → `<experiment>-chaos`

**Node experiments** (node-cpu-hog, node-memory-hog):
- ChaosEngine name: `kube-proxy-<experiment>-chaos` → `<experiment>-chaos`
- Cleanup command updated accordingly

As suggested by @amityt in https://github.com/litmuschaos/litmus/issues/4974#issuecomment-3302339001

Closes litmuschaos/litmus#4974

cc @amityt @Vr00mm